### PR TITLE
Simpler properties

### DIFF
--- a/src/FormatterManager.php
+++ b/src/FormatterManager.php
@@ -23,7 +23,7 @@ class FormatterManager
 
     public function getFormatter($format, $annotationData = [])
     {
-        if (array_key_exists($format, $this->formatters)) {
+        if (is_string($format) && array_key_exists($format, $this->formatters)) {
             $formatter = new $this->formatters[$format];
             if ($formatter instanceof ConfigurationAwareInterface) {
                 $formatter->configure($annotationData);

--- a/src/Formatters/TableFormatter.php
+++ b/src/Formatters/TableFormatter.php
@@ -8,6 +8,7 @@ use Consolidation\OutputFormatters\FormatterInterface;
 use Consolidation\OutputFormatters\ConfigurationAwareInterface;
 use Consolidation\OutputFormatters\Transformations\TableTransformation;
 use Consolidation\OutputFormatters\Transformations\PropertyParser;
+use Consolidation\OutputFormatters\Transformations\ReorderFields;
 
 class TableFormatter implements FormatterInterface, ConfigurationAwareInterface
 {
@@ -41,7 +42,8 @@ class TableFormatter implements FormatterInterface, ConfigurationAwareInterface
             'fields' => $this->defaultFields,
             'include-field-labels' => true,
         ];
-        $fieldLabels = $this->selectFieldLabels($options['fields'], $this->fieldLabels, $data);
+        $reorderer = new ReorderFields();
+        $fieldLabels = $reorderer->reorder($options['fields'], $this->fieldLabels, $data);
         $tableTransformer = new TableTransformation($data, $fieldLabels, $options);
 
         $table = new Table($output);
@@ -51,24 +53,5 @@ class TableFormatter implements FormatterInterface, ConfigurationAwareInterface
         }
         $table->setRows($tableTransformer->getData());
         $table->render();
-    }
-
-    protected function selectFieldLabels($fields, $fieldLabels, $data)
-    {
-        $result = [];
-        if (empty($fieldLabels)) {
-            $fieldLabels = array_combine(array_keys($data[0]), array_keys($data[0]));
-        }
-        if (empty($fields)) {
-            return $fieldLabels;
-        }
-        foreach ($fields as $field) {
-            if (array_key_exists($field, $data[0])) {
-                if (array_key_exists($field, $fieldLabels)) {
-                    $result[$field] = $fieldLabels[$field];
-                }
-            }
-        }
-        return $result;
     }
 }

--- a/src/Transformations/PropertyParser.php
+++ b/src/Transformations/PropertyParser.php
@@ -22,14 +22,15 @@ class PropertyParser
 {
     public static function parse($data)
     {
-        if (is_string($data)) {
-            $result = [];
-            $lines = explode("\n", $data);
-            foreach ($lines as $line) {
-                list($key, $value) = explode(':', trim($line), 2) + ['', ''];
-                $result[$key] = trim($value);
-            }
-            return $result;
+        if (!is_string($data)) {
+            return $data;
         }
+        $result = [];
+        $lines = explode("\n", $data);
+        foreach ($lines as $line) {
+            list($key, $value) = explode(':', trim($line), 2) + ['', ''];
+            $result[$key] = trim($value);
+        }
+        return $result;
     }
 }

--- a/src/Transformations/PropertyParser.php
+++ b/src/Transformations/PropertyParser.php
@@ -1,8 +1,6 @@
 <?php
 namespace Consolidation\OutputFormatters\Transformations;
 
-use Symfony\Component\Yaml\Yaml;
-
 /**
  * Transform a string of properties into a PHP associative array.
  *
@@ -25,8 +23,13 @@ class PropertyParser
     public static function parse($data)
     {
         if (is_string($data)) {
-            $data = Yaml::parse(trim($data));
+            $result = [];
+            $lines = explode("\n", $data);
+            foreach ($lines as $line) {
+                list($key, $value) = explode(':', trim($line), 2) + ['', ''];
+                $result[$key] = trim($value);
+            }
+            return $result;
         }
-        return $data;
     }
 }

--- a/src/Transformations/ReorderFields.php
+++ b/src/Transformations/ReorderFields.php
@@ -1,0 +1,63 @@
+<?php
+namespace Consolidation\OutputFormatters\Transformations;
+
+/**
+ * Reorder the field labels based on the user-selected fields
+ * to display.
+ */
+class ReorderFields
+{
+    /**
+     * Given a simple list of user-supplied field keys or field labels,
+     * return a reordered version of the field labels matching the
+     * user selection.
+     *
+     * @param string|array $fields The user-selected fields
+     * @param array $fieldLabels An associative array mapping the field
+     *   key to the field label
+     * @param array $data The data that will be rendered.
+     *
+     * @return array
+     */
+    public function reorder($fields, $fieldLabels, $data)
+    {
+        $fields = $this->getSelectedFieldKeys($fields, $fieldLabels);
+        $result = [];
+        if (empty($fieldLabels)) {
+            $fieldLabels = array_combine(array_keys($data[0]), array_keys($data[0]));
+        }
+        if (empty($fields)) {
+            return $fieldLabels;
+        }
+        return $this->reorderFieldLabels($fields, $fieldLabels, $data);
+    }
+
+    protected function reorderFieldLabels($fields, $fieldLabels, $data)
+    {
+        foreach ($fields as $field) {
+            if (array_key_exists($field, $data[0])) {
+                if (array_key_exists($field, $fieldLabels)) {
+                    $result[$field] = $fieldLabels[$field];
+                }
+            }
+        }
+        return $result;
+    }
+
+    protected function getSelectedFieldKeys($fields, $fieldLabels)
+    {
+        if (is_string($fields)) {
+            $fields = explode(',', $fields);
+        }
+        $fieldLablesReverseMap = array_combine(array_values($fieldLabels), array_keys($fieldLabels));
+        $selectedFields = [];
+        foreach ($fields as $field) {
+            if (array_key_exists($field, $fieldLabels)) {
+                $selectedFields[] = $field;
+            } elseif (array_key_exists($field, $fieldLablesReverseMap)) {
+                $selectedFields[] = $fieldLablesReverseMap[$field];
+            }
+        }
+        return $selectedFields;
+    }
+}

--- a/src/Transformations/ReorderFields.php
+++ b/src/Transformations/ReorderFields.php
@@ -22,7 +22,6 @@ class ReorderFields
     public function reorder($fields, $fieldLabels, $data)
     {
         $fields = $this->getSelectedFieldKeys($fields, $fieldLabels);
-        $result = [];
         if (empty($fieldLabels)) {
             $fieldLabels = array_combine(array_keys($data[0]), array_keys($data[0]));
         }
@@ -34,6 +33,7 @@ class ReorderFields
 
     protected function reorderFieldLabels($fields, $fieldLabels, $data)
     {
+        $result = [];
         foreach ($fields as $field) {
             if (array_key_exists($field, $data[0])) {
                 if (array_key_exists($field, $fieldLabels)) {

--- a/tests/testFormatters.php
+++ b/tests/testFormatters.php
@@ -417,5 +417,6 @@ EOT;
         ];
         $this->assertFormattedOutputMatches($expected, 'table', $data, $annotationData);
         $this->assertFormattedOutputMatches($expectedWithReorderedFields, 'table', $data, $annotationData, ['fields' => ['three', 'one']]);
+        $this->assertFormattedOutputMatches($expectedWithReorderedFields, 'table', $data, $annotationData, ['fields' => ['San', 'Ichi']]);
     }
 }


### PR DESCRIPTION
We cannot use the Yaml parser for the property parser, as our annotation library does not suitably maintain spacing of the lines. Make a simpler single-level parser instead.
