### PR TITLE
Automatically convert tables to strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Change Log
+
+### 1.1.0 - 14 September 2016
+
+Add tab-separated-value (tsv) formatter.
+
+
+### 1.0.0 - 19 May 2016
+
+First stable release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+### 2.0.0 - 15 September 2016
+
+Have the default `string` format convert the result into a tab-separated-value table if possible.  Commands may select a single field to emit in this instance with an annotation:
+
+  @single-field-default email
+
+By this means, a given command may by default emit a single value, but also provide more rich output that may be shown by selecting --format=table, --format=yaml or the like.
+
+This change might cause some commands to produce output in situations that previously were not documented as producing output.  Therefore, this change is considered to be not backwards-compatible with previous releases.
+
+
 ### 1.1.0 - 14 September 2016
 
 Add tab-separated-value (tsv) formatter.

--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 Apply transformations to structured data to write output in different formats.
 
-[![Travis CI](https://travis-ci.org/consolidation-org/output-formatters.svg?branch=master)](https://travis-ci.org/consolidation-org/output-formatters) [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/consolidation-org/output-formatters/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/consolidation-org/output-formatters/?branch=master) [![Coverage Status](https://coveralls.io/repos/github/consolidation-org/output-formatters/badge.svg?branch=master)](https://coveralls.io/github/consolidation-org/output-formatters?branch=master) [![License](https://poser.pugx.org/consolidation/output-formatters/license)](https://packagist.org/packages/consolidation/output-formatters)
+[![Travis CI](https://travis-ci.org/consolidation/output-formatters.svg?branch=master)](https://travis-ci.org/consolidation/output-formatters) [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/consolidation/output-formatters/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/consolidation/output-formatters/?branch=master) [![Coverage Status](https://coveralls.io/repos/github/consolidation/output-formatters/badge.svg?branch=master)](https://coveralls.io/github/consolidation/output-formatters?branch=master) [![License](https://poser.pugx.org/consolidation/output-formatters/license)](https://packagist.org/packages/consolidation/output-formatters)
 
 ## Component Status
 
-Currently in use in [Robo](https://github.com/Codegyre/Robo).
+Currently in use in [Robo](https://github.com/consolidation/Robo).
 
 ## Motivation
 
 Formatters are used to allow simple commandline tool commands to be implemented in a manner that is completely independent from the Symfony Console output interfaces.  A command receives its input via its method parameters, and returns its result as structured data (e.g. a php standard object or array).  The structured data is then formatted by a formatter, and the result is printed.
 
-This process is managed by the [Consolidation/AnnotationCommand](https://github.com/consolidation-org/annotation-command) project.
+This process is managed by the [Consolidation/AnnotationCommand](https://github.com/consolidation/annotation-command) project.
 
 ## Example Formatter
 
@@ -78,7 +78,7 @@ Note that if your data structure is printed with some formatter other than the t
 
 ## API Usage
 
-It is recommended to use [Consolidation/AnnotationCommand](https://github.com/consolidation-org/annotation-command) to manage commands and formatters.  See the [AnnotationCommand API Usage](https://github.com/consolidation-org/annotation-command#api-usage) for details.
+It is recommended to use [Consolidation/AnnotationCommand](https://github.com/consolidation/annotation-command) to manage commands and formatters.  See the [AnnotationCommand API Usage](https://github.com/consolidation/annotation-command#api-usage) for details.
 
 The FormatterManager may also be used directly, if desired:
 ```

--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ Apply transformations to structured data to write output in different formats.
 
 Currently in use in [Robo](https://github.com/consolidation/Robo).
 
+## Library Usage
+
+This is a library intended to be used in some other project.  Require from your composer.json file:
+```
+    "require": {
+        "consolidation/output-formatters": "~1|~2"
+    },
+```
+If you require the feature that allows a data table to be automatically reduced to a single element when the `string` format is selected, then you should require version "~2" instead. In all other respects, the 1.x and 2.x versions are compatible.
+
 ## Motivation
 
 Formatters are used to allow simple commandline tool commands to be implemented in a manner that is completely independent from the Symfony Console output interfaces.  A command receives its input via its method parameters, and returns its result as structured data (e.g. a php standard object or array).  The structured data is then formatted by a formatter, and the result is printed.

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.x-dev"
+            "dev-master": "2.x-dev"
         }
     }
 }

--- a/src/FormatterManager.php
+++ b/src/FormatterManager.php
@@ -117,6 +117,8 @@ class FormatterManager
     public function write(OutputInterface $output, $format, $structuredOutput, FormatterOptions $options)
     {
         $formatter = $this->getFormatter((string)$format);
+        // Give the formatter a chance to override the options
+        $options = $this->overrideOptions($formatter, $structuredOutput, $options);
         $structuredOutput = $this->validateAndRestructure($formatter, $structuredOutput, $options);
         $formatter->write($output, $structuredOutput, $options);
     }
@@ -260,5 +262,21 @@ class FormatterManager
         if ($formatter instanceof OverrideRestructureInterface) {
             return $formatter->overrideRestructure($structuredOutput, $options);
         }
+    }
+
+    /**
+     * Allow the formatter to mess with the configuration options before any
+     * transformations et. al. get underway.
+     * @param FormatterInterface $formatter
+     * @param mixed $structuredOutput
+     * @param FormatterOptions $options
+     * @return FormatterOptions
+     */
+    public function overrideOptions(FormatterInterface $formatter, $structuredOutput, FormatterOptions $options)
+    {
+        if ($formatter instanceof OverrideOptionsInterface) {
+            return $formatter->overrideOptions($structuredOutput, $options);
+        }
+        return $options;
     }
 }

--- a/src/FormatterOptions.php
+++ b/src/FormatterOptions.php
@@ -43,6 +43,7 @@ class FormatterOptions
     const ROW_LABELS = 'row-labels';
     const FIELD_LABELS = 'field-labels';
     const DEFAULT_FIELDS = 'default-fields';
+    const SINGLE_FIELD_DEFAULT = 'single-field-default';
     const DELIMITER = 'delimiter';
 
     public function __construct($configurationData = [], $options = [])
@@ -63,7 +64,19 @@ class FormatterOptions
     public function get($key, $defaults = [], $default = false)
     {
         $value = $this->fetch($key, $defaults, $default);
-        return $this->parse($key, $value);
+        $result = $this->parse($key, $value);
+        $result = $this->convert($key, $defaults, $result);
+        return $result;
+    }
+
+    public function convert($key, $defaults, $result)
+    {
+        if (array_key_exists($key, $defaults) && is_bool($defaults[$key])) {
+            if ($result === 'no') {
+                return false;
+            }
+        }
+        return $result;
     }
 
     public function getXmlSchema()

--- a/src/Formatters/CsvFormatter.php
+++ b/src/Formatters/CsvFormatter.php
@@ -75,7 +75,8 @@ class CsvFormatter implements FormatterInterface, ValidationInterface, RenderDat
     {
         $defaults = $this->getDefaultFormatterOptions();
 
-        if ($options->get(FormatterOptions::INCLUDE_FIELD_LABELS, $defaults) && ($data instanceof TableTransformation)) {
+        $includeFieldLabels = $options->get(FormatterOptions::INCLUDE_FIELD_LABELS, $defaults);
+        if ($includeFieldLabels && ($data instanceof TableTransformation)) {
             $headers = $data->getHeaders();
             $this->writeOneLine($output, $headers, $options);
         }

--- a/src/Formatters/TsvFormatter.php
+++ b/src/Formatters/TsvFormatter.php
@@ -17,6 +17,13 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class TsvFormatter extends CsvFormatter
 {
+    protected function getDefaultFormatterOptions()
+    {
+        return [
+            FormatterOptions::INCLUDE_FIELD_LABELS => false,
+        ];
+    }
+
     protected function writeOneLine(OutputInterface $output, $data, $options)
     {
         $output->writeln($this->tsvEscape($data));

--- a/src/OverrideOptionsInterface.php
+++ b/src/OverrideOptionsInterface.php
@@ -1,0 +1,15 @@
+<?php
+namespace Consolidation\OutputFormatters;
+
+interface OverrideOptionsInterface
+{
+    /**
+     * Allow the formatter to mess with the configuration options before any
+     * transformations et. al. get underway.
+     *
+     * @param mixed $structuredOutput Data to restructure
+     * @param FormatterOptions $options Formatting options
+     * @return FormatterOptions
+     */
+    public function overrideOptions($structuredOutput, FormatterOptions $options);
+}

--- a/tests/testFormatters.php
+++ b/tests/testFormatters.php
@@ -357,6 +357,24 @@ EOT;
         $this->assertFormattedOutputMatches($expected, '', $data);
     }
 
+    function testRenderTableAsString()
+    {
+        $data = new RowsOfFields([['f1' => 'A', 'f2' => 'B', 'f3' => 'C'], ['f1' => 'x', 'f2' => 'y', 'f3' => 'z']]);
+        $expected = "A\tB\tC\nx\ty\tz";
+
+        $this->assertFormattedOutputMatches($expected, 'string', $data);
+    }
+
+    function testRenderTableAsStringWithSingleField()
+    {
+        $data = new RowsOfFields([['f1' => 'q', 'f2' => 'r', 'f3' => 's'], ['f1' => 'x', 'f2' => 'y', 'f3' => 'z']]);
+        $expected = "q\nx";
+
+        $options = new FormatterOptions([FormatterOptions::SINGLE_FIELD_DEFAULT => 'f1']);
+
+        $this->assertFormattedOutputMatches($expected, 'string', $data, $options);
+    }
+
     function testSimpleCsv()
     {
         $data = ['a', 'b', 'c'];

--- a/tests/testFormatters.php
+++ b/tests/testFormatters.php
@@ -375,6 +375,16 @@ EOT;
         $this->assertFormattedOutputMatches($expected, 'string', $data, $options);
     }
 
+    function testRenderTableAsStringWithSingleFieldAndUserSelectedField()
+    {
+        $data = new RowsOfFields([['f1' => 'q', 'f2' => 'r', 'f3' => 's'], ['f1' => 'x', 'f2' => 'y', 'f3' => 'z']]);
+        $expected = "r\ny";
+
+        $options = new FormatterOptions([FormatterOptions::SINGLE_FIELD_DEFAULT => 'f1']);
+
+        $this->assertFormattedOutputMatches($expected, 'string', $data, $options, ['fields' => 'f2']);
+    }
+
     function testSimpleCsv()
     {
         $data = ['a', 'b', 'c'];

--- a/tests/testFormatters.php
+++ b/tests/testFormatters.php
@@ -479,6 +479,19 @@ a,b,c
 x,,z
 EOT;
         $this->assertFormattedOutputMatches($expectedCsv, 'csv', $data);
+
+        $expectedTsv = <<<EOT
+a\tb\tc
+x\t\tz
+EOT;
+        $this->assertFormattedOutputMatches($expectedTsv, 'tsv', $data);
+
+        $expectedTsvWithHeaders = <<<EOT
+One\tTwo\tThree
+a\tb\tc
+x\t\tz
+EOT;
+        $this->assertFormattedOutputMatches($expectedTsvWithHeaders, 'tsv', $data, new FormatterOptions(), ['include-field-labels' => true]);
     }
 
     protected function simpleTableExampleData()


### PR DESCRIPTION
Allow tables to render in tsv format without field labels when 'string' format is selected.

To provide a default field to render, commands can annotate with:

`@single-field-default fieldname`

Without this, the entire table will render.  With this, just the one specified field will be rendered, unless the user stipulates --field=otherfield to select a different one.
