### PR TITLE
Remove unwanted extra layer of nesting 

### DIFF
--- a/src/FormatterManager.php
+++ b/src/FormatterManager.php
@@ -15,6 +15,7 @@ use Consolidation\OutputFormatters\Transformations\SimplifyToArrayInterface;
 use Consolidation\OutputFormatters\Validate\ValidationInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Consolidation\OutputFormatters\StructuredData\OriginalDataInterface;
 
 /**
  * Manage a collection of formatters; return one on request.
@@ -320,6 +321,10 @@ class FormatterManager
             if ($simplifier->canSimplify($outputDataType)) {
                 $structuredOutput = $simplifier->simplifyToArray($structuredOutput, $options);
             }
+        }
+        // Convert data structure back into its original form, if necessary.
+        if ($structuredOutput instanceof OriginalDataInterface) {
+            return $structuredOutput->getOriginalData();
         }
         // Convert \ArrayObjects to a simple array.
         if ($structuredOutput instanceof \ArrayObject) {

--- a/src/StructuredData/AbstractStructuredList.php
+++ b/src/StructuredData/AbstractStructuredList.php
@@ -32,12 +32,17 @@ abstract class AbstractStructuredList extends \ArrayObject implements Restructur
         $defaults = $this->defaultOptions();
         $fieldLabels = $this->getReorderedFieldLabels($data, $options, $defaults);
 
-        $tableTransformer = new TableTransformation($data, $fieldLabels, $options->get(FormatterOptions::ROW_LABELS, $defaults));
+        $tableTransformer = $this->instantiateTableTransformation($data, $fieldLabels, $options->get(FormatterOptions::ROW_LABELS, $defaults));
         if ($options->get(FormatterOptions::LIST_ORIENTATION, $defaults)) {
             $tableTransformer->setLayout(TableTransformation::LIST_LAYOUT);
         }
 
         return $tableTransformer;
+    }
+
+    protected function instantiateTableTransformation($data, $fieldLabels, $rowLabels)
+    {
+        return new TableTransformation($data, $fieldLabels, $rowLabels);
     }
 
     protected function getReorderedFieldLabels($data, $options, $defaults)

--- a/src/StructuredData/AssociativeList.php
+++ b/src/StructuredData/AssociativeList.php
@@ -6,6 +6,7 @@ use Consolidation\OutputFormatters\StructuredData\ListDataInterface;
 use Consolidation\OutputFormatters\Transformations\PropertyParser;
 use Consolidation\OutputFormatters\Transformations\ReorderFields;
 use Consolidation\OutputFormatters\Transformations\TableTransformation;
+use Consolidation\OutputFormatters\Transformations\AssociativeListTableTransformation;
 
 /**
  * Holds an array where each element of the array is one
@@ -48,5 +49,10 @@ class AssociativeList extends AbstractStructuredList
         return [
             FormatterOptions::LIST_ORIENTATION => true,
         ] + parent::defaultOptions();
+    }
+
+    protected function instantiateTableTransformation($data, $fieldLabels, $rowLabels)
+    {
+        return new AssociativeListTableTransformation($data, $fieldLabels, $rowLabels);
     }
 }

--- a/src/StructuredData/OriginalDataInterface.php
+++ b/src/StructuredData/OriginalDataInterface.php
@@ -1,0 +1,11 @@
+<?php
+namespace Consolidation\OutputFormatters\StructuredData;
+
+interface OriginalDataInterface
+{
+    /**
+     * Return the original data for this table.  Used by any
+     * formatter that expects an array.
+     */
+    public function getOriginalData();
+}

--- a/src/StructuredData/TableDataInterface.php
+++ b/src/StructuredData/TableDataInterface.php
@@ -4,6 +4,12 @@ namespace Consolidation\OutputFormatters\StructuredData;
 interface TableDataInterface
 {
     /**
+     * Return the original data for this table.  Used by any
+     * formatter that is -not- a table.
+     */
+    public function getOriginalData();
+
+    /**
      * Convert structured data into a form suitable for use
      * by the table formatter.
      *

--- a/src/Transformations/AssociativeListTableTransformation.php
+++ b/src/Transformations/AssociativeListTableTransformation.php
@@ -1,0 +1,11 @@
+<?php
+namespace Consolidation\OutputFormatters\Transformations;
+
+class AssociativeListTableTransformation extends TableTransformation
+{
+    public function getOriginalData()
+    {
+        $data = $this->getArrayCopy();
+        return $data[0];
+    }
+}

--- a/src/Transformations/TableTransformation.php
+++ b/src/Transformations/TableTransformation.php
@@ -2,8 +2,9 @@
 namespace Consolidation\OutputFormatters\Transformations;
 
 use Consolidation\OutputFormatters\StructuredData\TableDataInterface;
+use Consolidation\OutputFormatters\StructuredData\OriginalDataInterface;
 
-class TableTransformation extends \ArrayObject implements TableDataInterface
+class TableTransformation extends \ArrayObject implements TableDataInterface, OriginalDataInterface
 {
     protected $headers;
     protected $rowLabels;
@@ -80,7 +81,7 @@ class TableTransformation extends \ArrayObject implements TableDataInterface
         return $rowid;
     }
 
-    public function getData()
+    public function getOriginalData()
     {
         return $this->getArrayCopy();
     }

--- a/tests/testFormatters.php
+++ b/tests/testFormatters.php
@@ -970,12 +970,10 @@ EOT;
         $this->assertFormattedOutputMatches($expectedWithReorderedFields, 'table', $data, $configurationData, ['fields' => ['San', 'Ichi']]);
 
         $expectedJson = <<<EOT
-[
-    {
-        "three": "carrot",
-        "one": "apple"
-    }
-]
+{
+    "three": "carrot",
+    "one": "apple"
+}
 EOT;
         $this->assertFormattedOutputMatches($expectedJson, 'json', $data, $configurationData, ['fields' => ['San', 'Ichi']]);
     }


### PR DESCRIPTION
When formatting an AssociativeList with an array formatter (json, yaml, etc.), the data was wrapped in an unwanted extra array.  This PR puts the data format back the way it was supposed to be.
