### PR TITLE
Add RenderCellCollections to structured lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### 2.1.0 - 7 November 2016
+
+- Add RenderCellCollections to structured lists, so that commands may add renderers to structured data without defining a new structured data subclass.
+
 ### 2.0.1 - 4 October 2016
 
 - Throw an exception if the client requests a field that does not exist.

--- a/src/StructuredData/AbstractStructuredList.php
+++ b/src/StructuredData/AbstractStructuredList.php
@@ -14,8 +14,9 @@ use Consolidation\OutputFormatters\Transformations\TableTransformation;
  *
  * It is presumed that every row contains the same keys.
  */
-abstract class AbstractStructuredList extends \ArrayObject implements RestructureInterface, ListDataInterface
+abstract class AbstractStructuredList extends \ArrayObject implements RestructureInterface, ListDataInterface, RenderCellCollectionInterface
 {
+    use RenderCellCollectionTrait;
     protected $data;
 
     public function __construct($data)

--- a/src/StructuredData/CallableRenderer.php
+++ b/src/StructuredData/CallableRenderer.php
@@ -18,6 +18,6 @@ class CallableRenderer implements RenderCellInterface
      */
     public function renderCell($key, $cellData, FormatterOptions $options)
     {
-        return ($this->renderFunction)($key, $cellData, $options);
+        return call_user_func($this->renderFunction, $key, $cellData, $options);
     }
 }

--- a/src/StructuredData/CallableRenderer.php
+++ b/src/StructuredData/CallableRenderer.php
@@ -1,0 +1,23 @@
+<?php
+namespace Consolidation\OutputFormatters\StructuredData;
+
+use Consolidation\OutputFormatters\Options\FormatterOptions;
+
+class CallableRenderer implements RenderCellInterface
+{
+    /** @var callable */
+    protected $renderFunction;
+
+    public function __construct(callable $renderFunction)
+    {
+        $this->renderFunction = $renderFunction;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function renderCell($key, $cellData, FormatterOptions $options)
+    {
+        return ($this->renderFunction)($key, $cellData, $options);
+    }
+}

--- a/src/StructuredData/RenderCellCollectionInterface.php
+++ b/src/StructuredData/RenderCellCollectionInterface.php
@@ -1,0 +1,16 @@
+<?php
+namespace Consolidation\OutputFormatters\StructuredData;
+
+interface RenderCellCollectionInterface extends RenderCellInterface
+{
+    const PRIORITY_FIRST = 'first';
+    const PRIORITY_NORMAL = 'normal';
+    const PRIORITY_FALLBACK = 'fallback';
+
+    /**
+     * Add a renderer
+     *
+     * @return $this
+     */
+    public function addRenderer(RenderCellInterface $renderer);
+}

--- a/src/StructuredData/RenderCellCollectionTrait.php
+++ b/src/StructuredData/RenderCellCollectionTrait.php
@@ -42,7 +42,7 @@ trait RenderCellCollectionTrait
     {
         $flattenedRendererList = array_reduce(
             $this->rendererList,
-            function ($carry , $item) {
+            function ($carry, $item) {
                 return array_merge($carry, $item);
             },
             []

--- a/src/StructuredData/RenderCellCollectionTrait.php
+++ b/src/StructuredData/RenderCellCollectionTrait.php
@@ -1,0 +1,59 @@
+<?php
+namespace Consolidation\OutputFormatters\StructuredData;
+
+use Consolidation\OutputFormatters\Options\FormatterOptions;
+
+trait RenderCellCollectionTrait
+{
+
+    /** @var RenderCellInterface[] */
+    protected $rendererList = [
+        RenderCellCollectionInterface::PRIORITY_FIRST => [],
+        RenderCellCollectionInterface::PRIORITY_NORMAL => [],
+        RenderCellCollectionInterface::PRIORITY_FALLBACK => [],
+    ];
+
+    /**
+     * Add a renderer
+     *
+     * @return $this
+     */
+    public function addRenderer(RenderCellInterface $renderer, $priority = RenderCellCollectionInterface::PRIORITY_NORMAL)
+    {
+        $this->rendererList[$priority][] = $renderer;
+        return $this;
+    }
+
+    /**
+     * Add a callable as a renderer
+     *
+     * @return $this
+     */
+    public function addRendererFunction(callable $rendererFn, $priority = RenderCellCollectionInterface::PRIORITY_NORMAL)
+    {
+        $renderer = new CallableRenderer($rendererFn);
+        return $this->addRenderer($renderer, $priority);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function renderCell($key, $cellData, FormatterOptions $options)
+    {
+        $flattenedRendererList = array_reduce(
+            $this->rendererList,
+            function ($carry , $item) {
+                return array_merge($carry, $item);
+            },
+            []
+        );
+
+        foreach ($flattenedRendererList as $renderer) {
+            $cellData = $renderer->renderCell($key, $cellData, $options);
+            if (is_string($cellData)) {
+                return $cellData;
+            }
+        }
+        return $cellData;
+    }
+}

--- a/src/StructuredData/RenderCellInterface.php
+++ b/src/StructuredData/RenderCellInterface.php
@@ -7,12 +7,14 @@ interface RenderCellInterface
 {
     /**
      * Convert the contents of one table cell into a string,
-     * so that it may be placed in the table.
+     * so that it may be placed in the table.  Renderer should
+     * return the $cellData passed to it if it does not wish to
+     * process it.
      *
      * @param string $key Identifier of the cell being rendered
      * @param mixed $cellData The data to render
      *
-     * @return string
+     * @return mixed
      */
     public function renderCell($key, $cellData, FormatterOptions $options);
 }

--- a/tests/testFormatters.php
+++ b/tests/testFormatters.php
@@ -916,6 +916,29 @@ EOT;
         $this->assertFormattedOutputMatches($expectedCsv, 'csv', $data, $options);
     }
 
+    protected function associativeListWithRenderer()
+    {
+        $data = [
+            'one' => 'apple',
+            'two' => ['banana', 'plantain'],
+            'three' => 'carrot',
+            'four' => ['peaches', 'pumpkin pie'],
+        ];
+        $list = new AssociativeList($data);
+
+        $list->addRendererFunction(
+            function ($key, $cellData, FormatterOptions $options)
+            {
+                if (is_array($cellData)) {
+                    return implode(',', $cellData);
+                }
+                return $cellData;
+            }
+        );
+
+        return $list;
+    }
+
     protected function associativeListWithCsvCells()
     {
         $data = [
@@ -929,8 +952,12 @@ EOT;
 
     function testAssociativeListWithCsvCells()
     {
-        $data = $this->associativeListWithCsvCells();
+        $this->doAssociativeListWithCsvCells($this->associativeListWithRenderer());
+        $this->doAssociativeListWithCsvCells($this->associativeListWithCsvCells());
+    }
 
+    function doAssociativeListWithCsvCells($data)
+    {
         $expected = <<<EOT
  ------- ---------------------
   One     apple


### PR DESCRIPTION
### Overview
This pull request:

- [X] Adds a feature
- [ ] Fixes a bug
- [ ] Breaks backwards compatibility
- [ ] Needs tests

### Description
It is now possible to add a callback function directly to a RowOfFields or AssociativeList data object to provide a quick drop-in cell renderer.