### PR TITLE
Missing data test

### DIFF
--- a/src/Transformations/ReorderFields.php
+++ b/src/Transformations/ReorderFields.php
@@ -24,13 +24,13 @@ class ReorderFields
      */
     public function reorder($fields, $fieldLabels, $data)
     {
+        $firstRow = reset($data);
         if (empty($fieldLabels) && !empty($data)) {
-            $firstRow = reset($data);
             $fieldLabels = array_combine(array_keys($firstRow), array_map('ucfirst', array_keys($firstRow)));
         }
         $fields = $this->getSelectedFieldKeys($fields, $fieldLabels);
         if (empty($fields)) {
-            return $fieldLabels;
+            return array_intersect_key($fieldLabels, $firstRow);
         }
         return $this->reorderFieldLabels($fields, $fieldLabels, $data);
     }

--- a/tests/testFormatters.php
+++ b/tests/testFormatters.php
@@ -851,6 +851,7 @@ EOT;
         $this->assertFormattedOutputMatches('Should throw an exception before comparing the table data', 'table', $data->getArrayCopy());
     }
 
+
     function testSimpleList()
     {
         $data = $this->simpleListExampleData();
@@ -863,6 +864,25 @@ EOT;
  ------- --------
 EOT;
         $this->assertFormattedOutputMatches($expected, 'table', $data);
+
+        $expected = <<<EOT
+ ----- --------
+  I     apple
+  II    banana
+  III   carrot
+ ----- --------
+EOT;
+        // If we provide field labels, then the output will change to reflect that.
+        $formatterOptionsWithFieldLables = new FormatterOptions();
+        $formatterOptionsWithFieldLables
+            ->setFieldLabels(['one' => 'I', 'two' => 'II', 'three' => 'III']);
+        $this->assertFormattedOutputMatches($expected, 'table', $data, $formatterOptionsWithFieldLables);
+
+        // Adding an extra field that does not exist in the data set should not change the output
+        $formatterOptionsWithExtraFieldLables = new FormatterOptions();
+        $formatterOptionsWithExtraFieldLables
+            ->setFieldLabels(['one' => 'I', 'two' => 'II', 'three' => 'III', 'four' => 'IV']);
+        $this->assertFormattedOutputMatches($expected, 'table', $data, $formatterOptionsWithExtraFieldLables);
 
         $expectedRotated = <<<EOT
  ------- -------- --------


### PR DESCRIPTION
### Overview
This pull request:

- [X] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [X] Has tests that cover changes

### Description
When output data does not contain all of the fields, only a subset of the available fields should be displayed. This PR fixes a bug that caused all fields to be displayed even when the output data contained only a subset.
