### PR TITLE
Fix bug in table output when data is empty.

### DIFF
--- a/src/Transformations/ReorderFields.php
+++ b/src/Transformations/ReorderFields.php
@@ -25,6 +25,9 @@ class ReorderFields
     public function reorder($fields, $fieldLabels, $data)
     {
         $firstRow = reset($data);
+        if (!$firstRow) {
+            $firstRow = $fieldLabels;
+        }
         if (empty($fieldLabels) && !empty($data)) {
             $fieldLabels = array_combine(array_keys($firstRow), array_map('ucfirst', array_keys($firstRow)));
         }

--- a/tests/testFormatters.php
+++ b/tests/testFormatters.php
@@ -851,6 +851,22 @@ EOT;
         $this->assertFormattedOutputMatches('Should throw an exception before comparing the table data', 'table', $data->getArrayCopy());
     }
 
+    function testEmptyList()
+    {
+        $data = new RowsOfFields([]);
+
+        $expected = <<<EOT
+ --- ---- -----
+  I   II   III
+ --- ---- -----
+EOT;
+
+        // If we provide field labels, then the output will change to reflect that.
+        $formatterOptionsWithFieldLables = new FormatterOptions();
+        $formatterOptionsWithFieldLables
+            ->setFieldLabels(['one' => 'I', 'two' => 'II', 'three' => 'III']);
+        $this->assertFormattedOutputMatches($expected, 'table', $data, $formatterOptionsWithFieldLables);
+    }
 
     function testSimpleList()
     {


### PR DESCRIPTION
### Overview
This pull request:

- [X] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Description
Previous bugfix filtered data columns down when table was missing data from some rows. This introduced a data-access bug when the entire dataset was empty, though.

