### PR TITLE
Rename AssociativeList to PropertyList.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 3.0.0 - 14 November 2016
 
 - **Breaking** The RenderCellInterface is now provided a reference to the entire row data. Existing clients need only add the new parameter to their method defnition to update.
+- Rename AssociativeList to PropertyList, as many people seemed to find the former name confusing. AssociativeList is still available for use to preserve backwards compatibility, but it is deprecated.
 
 
 ### 2.1.0 - 7 November 2016
@@ -13,7 +14,7 @@
 ### 2.0.1 - 4 October 2016
 
 - Throw an exception if the client requests a field that does not exist.
-- Remove unwanted extra layer of nesting when formatting an AssociativeList with an array formatter (json, yaml, etc.).
+- Remove unwanted extra layer of nesting when formatting an PropertyList with an array formatter (json, yaml, etc.).
 
 
 ### 2.0.0 - 30 September 2016

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Formatters may also implement different interfaces to alter the behavior of the 
 Most formatters will operate on any array or ArrayObject data. Some formatters require that specific data types be used. The following data types, all of which are subclasses of ArrayObject, are available for use:
 
 - `RowsOfFields`: Each row contains an associative array of field:value pairs. It is also assumed that the fields of each row are the same for every row. This format is ideal for displaying in a table, with labels in the top row.
-- `AssociativeList`: Each row contains a field:value pair. Each field is unique. This format is ideal for displaying in a table, with labels in the first column and values in the second common.
+- `PropertyList`: Each row contains a field:value pair. Each field is unique. This format is ideal for displaying in a table, with labels in the first column and values in the second common.
 - `DOMDocument`: The standard PHP DOM document class may be used by functions that need to be able to presicely specify the exact attributes and children when the XML output format is used.
 
 Commands that return table structured data with fields can be filtered and/or re-ordered by using the --fields option. These structured data types can also be formatted into a more generic type such as yaml or json, even after being filtered. This capabilities are not available if the data is returned in a bare php array.
@@ -62,13 +62,13 @@ A function may also define its own structured data type to return, usually by ex
 - `ListDataInterface`: Any structured data object that implements this interface may use the `getListData()` method to produce the data set that will be used with the list formatter.
 - `TableDataInterface`: Any structured data object that implements this interface may use the `getTableData()` method to produce the data set that will be used with the table formatter.
 - `RenderCellInterface`: Structured data can also provide fine-grain control over how each cell in a table is rendered by implementing the RenderCellInterface.  See the section below for information on how this is done.
-- `RestructureInterface`: The restructure interface can be implemented by a structured data object to restructure the data in response to options provided by the user. For example, the RowsOfFields and AssociativeList data types use this interface to select and reorder the fields that were selected to appear in the output. Custom data types usually will not need to implement this interface, as they can inherit this behavior by extending RowsOfFields or AssociativeList.
+- `RestructureInterface`: The restructure interface can be implemented by a structured data object to restructure the data in response to options provided by the user. For example, the RowsOfFields and PropertyList data types use this interface to select and reorder the fields that were selected to appear in the output. Custom data types usually will not need to implement this interface, as they can inherit this behavior by extending RowsOfFields or PropertyList.
 
 Additionally, structured data may be simplified to arrays via an array simplification object. To provide an array simplifier, implement `SimplifyToArrayInterface`, and register the simplifier via `FormatterManager::addSimplifier()`.
 
 ## Rendering Table Cells
 
-By default, both the RowsOfFields and AssociativeList data types presume that the contents of each cell is a simple string. To render more complicated cell contents, create a custom structured data class by extending either RowsOfFields or AssociativeList, as desired, and implement RenderCellInterface.  The `renderCell()` method of your class will then be called for each cell, and you may act on it as appropriate.
+By default, both the RowsOfFields and PropertyList data types presume that the contents of each cell is a simple string. To render more complicated cell contents, create a custom structured data class by extending either RowsOfFields or PropertyList, as desired, and implement RenderCellInterface.  The `renderCell()` method of your class will then be called for each cell, and you may act on it as appropriate.
 ```php
 public function renderCell($key, $cellData, FormatterOptions $options, $rowData)
 {

--- a/docs/api.md
+++ b/docs/api.md
@@ -27,6 +27,7 @@
 - [\Consolidation\OutputFormatters\StructuredData\CallableRenderer](#class-consolidationoutputformattersstructureddatacallablerenderer)
 - [\Consolidation\OutputFormatters\StructuredData\ListDataInterface (interface)](#interface-consolidationoutputformattersstructureddatalistdatainterface)
 - [\Consolidation\OutputFormatters\StructuredData\OriginalDataInterface (interface)](#interface-consolidationoutputformattersstructureddataoriginaldatainterface)
+- [\Consolidation\OutputFormatters\StructuredData\PropertyList](#class-consolidationoutputformattersstructureddatapropertylist)
 - [\Consolidation\OutputFormatters\StructuredData\RenderCellCollectionInterface (interface)](#interface-consolidationoutputformattersstructureddatarendercellcollectioninterface)
 - [\Consolidation\OutputFormatters\StructuredData\RenderCellInterface (interface)](#interface-consolidationoutputformattersstructureddatarendercellinterface)
 - [\Consolidation\OutputFormatters\StructuredData\RestructureInterface (interface)](#interface-consolidationoutputformattersstructureddatarestructureinterface)
@@ -35,9 +36,9 @@
 - [\Consolidation\OutputFormatters\StructuredData\Xml\DomDataInterface (interface)](#interface-consolidationoutputformattersstructureddataxmldomdatainterface)
 - [\Consolidation\OutputFormatters\StructuredData\Xml\XmlSchema](#class-consolidationoutputformattersstructureddataxmlxmlschema)
 - [\Consolidation\OutputFormatters\StructuredData\Xml\XmlSchemaInterface (interface)](#interface-consolidationoutputformattersstructureddataxmlxmlschemainterface)
-- [\Consolidation\OutputFormatters\Transformations\AssociativeListTableTransformation](#class-consolidationoutputformatterstransformationsassociativelisttabletransformation)
 - [\Consolidation\OutputFormatters\Transformations\DomToArraySimplifier](#class-consolidationoutputformatterstransformationsdomtoarraysimplifier)
 - [\Consolidation\OutputFormatters\Transformations\OverrideRestructureInterface (interface)](#interface-consolidationoutputformatterstransformationsoverriderestructureinterface)
+- [\Consolidation\OutputFormatters\Transformations\PropertyListTableTransformation](#class-consolidationoutputformatterstransformationspropertylisttabletransformation)
 - [\Consolidation\OutputFormatters\Transformations\PropertyParser](#class-consolidationoutputformatterstransformationspropertyparser)
 - [\Consolidation\OutputFormatters\Transformations\ReorderFields](#class-consolidationoutputformatterstransformationsreorderfields)
 - [\Consolidation\OutputFormatters\Transformations\SimplifyToArrayInterface (interface)](#interface-consolidationoutputformatterstransformationssimplifytoarrayinterface)
@@ -144,7 +145,7 @@
 <hr /> 
 ### Class: \Consolidation\OutputFormatters\Formatters\CsvFormatter
 
-> Comma-separated value formatters Display the provided structured data in a comma-separated list. If there are multiple records provided, then they will be printed one per line.  The primary data types accepted are RowsOfFields and AssociativeList. The later behaves exactly like the former, save for the fact that it contains but a single row. This formmatter can also accept a PHP array; this is also interpreted as a single-row of data with no header.
+> Comma-separated value formatters Display the provided structured data in a comma-separated list. If there are multiple records provided, then they will be printed one per line.  The primary data types accepted are RowsOfFields and PropertyList. The later behaves exactly like the former, save for the fact that it contains but a single row. This formmatter can also accept a PHP array; this is also interpreted as a single-row of data with no header.
 
 | Visibility | Function |
 |:-----------|:---------|
@@ -181,7 +182,7 @@
 <hr /> 
 ### Class: \Consolidation\OutputFormatters\Formatters\ListFormatter
 
-> Display the data in a simple list. This formatter prints a plain, unadorned list of data, with each data item appearing on a separate line.  If you wish your list to contain headers, then use the table formatter, and wrap your data in an AssociativeList.
+> Display the data in a simple list. This formatter prints a plain, unadorned list of data, with each data item appearing on a separate line.  If you wish your list to contain headers, then use the table formatter, and wrap your data in an PropertyList.
 
 | Visibility | Function |
 |:-----------|:---------|
@@ -255,7 +256,7 @@
 <hr /> 
 ### Class: \Consolidation\OutputFormatters\Formatters\TableFormatter
 
-> Display a table of data with the Symfony Table class. This formatter takes data of either the RowsOfFields or AssociativeList data type.  Tables can be rendered with the rows running either vertically (the normal orientation) or horizontally.  By default, associative lists will be displayed as two columns, with the key in the first column and the value in the second column.
+> Display a table of data with the Symfony Table class. This formatter takes data of either the RowsOfFields or PropertyList data type.  Tables can be rendered with the rows running either vertically (the normal orientation) or horizontally.  By default, associative lists will be displayed as two columns, with the key in the first column and the value in the second column.
 
 | Visibility | Function |
 |:-----------|:---------|
@@ -300,7 +301,7 @@
 <hr /> 
 ### Class: \Consolidation\OutputFormatters\Formatters\XmlFormatter
 
-> Display a table of data with the Symfony Table class. This formatter takes data of either the RowsOfFields or AssociativeList data type.  Tables can be rendered with the rows running either vertically (the normal orientation) or horizontally.  By default, associative lists will be displayed as two columns, with the key in the first column and the value in the second column.
+> Display a table of data with the Symfony Table class. This formatter takes data of either the RowsOfFields or PropertyList data type.  Tables can be rendered with the rows running either vertically (the normal orientation) or horizontally.  By default, associative lists will be displayed as two columns, with the key in the first column and the value in the second column.
 
 | Visibility | Function |
 |:-----------|:---------|
@@ -391,18 +392,14 @@
 <hr /> 
 ### Class: \Consolidation\OutputFormatters\StructuredData\AssociativeList
 
-> Holds an array where each element of the array is one key : value pair.  The keys must be unique, as is typically the case for associative arrays.
+> Old name for PropertyList class.
 
 | Visibility | Function |
 |:-----------|:---------|
-| public | <strong>getListData(</strong><em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>mixed</em> |
-| public | <strong>restructure(</strong><em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>\Consolidation\OutputFormatters\StructuredData\Consolidation\OutputFormatters\Transformations\TableTransformation</em><br /><em>Restructure this data for output by converting it into a table transformation object.</em> |
-| protected | <strong>defaultOptions()</strong> : <em>void</em> |
-| protected | <strong>instantiateTableTransformation(</strong><em>mixed</em> <strong>$data</strong>, <em>mixed</em> <strong>$fieldLabels</strong>, <em>mixed</em> <strong>$rowLabels</strong>)</strong> : <em>void</em> |
 
-*This class extends [\Consolidation\OutputFormatters\StructuredData\AbstractStructuredList](#class-consolidationoutputformattersstructureddataabstractstructuredlist-abstract)*
+*This class extends [\Consolidation\OutputFormatters\StructuredData\PropertyList](#class-consolidationoutputformattersstructureddatapropertylist)*
 
-*This class implements [\Consolidation\OutputFormatters\StructuredData\RenderCellInterface](#interface-consolidationoutputformattersstructureddatarendercellinterface), [\Consolidation\OutputFormatters\StructuredData\RenderCellCollectionInterface](#interface-consolidationoutputformattersstructureddatarendercellcollectioninterface), [\Consolidation\OutputFormatters\StructuredData\ListDataInterface](#interface-consolidationoutputformattersstructureddatalistdatainterface), [\Consolidation\OutputFormatters\StructuredData\RestructureInterface](#interface-consolidationoutputformattersstructureddatarestructureinterface), \IteratorAggregate, \Traversable, \ArrayAccess, \Serializable, \Countable*
+*This class implements \Countable, \Serializable, \ArrayAccess, \Traversable, \IteratorAggregate, [\Consolidation\OutputFormatters\StructuredData\RestructureInterface](#interface-consolidationoutputformattersstructureddatarestructureinterface), [\Consolidation\OutputFormatters\StructuredData\ListDataInterface](#interface-consolidationoutputformattersstructureddatalistdatainterface), [\Consolidation\OutputFormatters\StructuredData\RenderCellCollectionInterface](#interface-consolidationoutputformattersstructureddatarendercellcollectioninterface), [\Consolidation\OutputFormatters\StructuredData\RenderCellInterface](#interface-consolidationoutputformattersstructureddatarendercellinterface)*
 
 <hr /> 
 ### Class: \Consolidation\OutputFormatters\StructuredData\CallableRenderer
@@ -427,6 +424,22 @@
 | Visibility | Function |
 |:-----------|:---------|
 | public | <strong>getOriginalData()</strong> : <em>mixed</em><br /><em>Return the original data for this table.  Used by any formatter that expects an array.</em> |
+
+<hr /> 
+### Class: \Consolidation\OutputFormatters\StructuredData\PropertyList
+
+> Holds an array where each element of the array is one key : value pair.  The keys must be unique, as is typically the case for associative arrays.
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>getListData(</strong><em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>mixed</em> |
+| public | <strong>restructure(</strong><em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>\Consolidation\OutputFormatters\StructuredData\Consolidation\OutputFormatters\Transformations\TableTransformation</em><br /><em>Restructure this data for output by converting it into a table transformation object.</em> |
+| protected | <strong>defaultOptions()</strong> : <em>void</em> |
+| protected | <strong>instantiateTableTransformation(</strong><em>mixed</em> <strong>$data</strong>, <em>mixed</em> <strong>$fieldLabels</strong>, <em>mixed</em> <strong>$rowLabels</strong>)</strong> : <em>void</em> |
+
+*This class extends [\Consolidation\OutputFormatters\StructuredData\AbstractStructuredList](#class-consolidationoutputformattersstructureddataabstractstructuredlist-abstract)*
+
+*This class implements [\Consolidation\OutputFormatters\StructuredData\RenderCellInterface](#interface-consolidationoutputformattersstructureddatarendercellinterface), [\Consolidation\OutputFormatters\StructuredData\RenderCellCollectionInterface](#interface-consolidationoutputformattersstructureddatarendercellcollectioninterface), [\Consolidation\OutputFormatters\StructuredData\ListDataInterface](#interface-consolidationoutputformattersstructureddatalistdatainterface), [\Consolidation\OutputFormatters\StructuredData\RestructureInterface](#interface-consolidationoutputformattersstructureddatarestructureinterface), \IteratorAggregate, \Traversable, \ArrayAccess, \Serializable, \Countable*
 
 <hr /> 
 ### Interface: \Consolidation\OutputFormatters\StructuredData\RenderCellCollectionInterface
@@ -510,17 +523,6 @@
 | public | <strong>arrayToXml(</strong><em>mixed</em> <strong>$structuredData</strong>)</strong> : <em>[\DOMDocument](http://php.net/manual/en/class.domdocument.php)</em><br /><em>Convert data to a format suitable for use in a list. By default, the array values will be used.  Implement ListDataInterface to use some other criteria (e.g. array keys).</em> |
 
 <hr /> 
-### Class: \Consolidation\OutputFormatters\Transformations\AssociativeListTableTransformation
-
-| Visibility | Function |
-|:-----------|:---------|
-| public | <strong>getOriginalData()</strong> : <em>mixed</em> |
-
-*This class extends [\Consolidation\OutputFormatters\Transformations\TableTransformation](#class-consolidationoutputformatterstransformationstabletransformation)*
-
-*This class implements [\Consolidation\OutputFormatters\StructuredData\OriginalDataInterface](#interface-consolidationoutputformattersstructureddataoriginaldatainterface), [\Consolidation\OutputFormatters\StructuredData\TableDataInterface](#interface-consolidationoutputformattersstructureddatatabledatainterface), \IteratorAggregate, \Traversable, \ArrayAccess, \Serializable, \Countable*
-
-<hr /> 
 ### Class: \Consolidation\OutputFormatters\Transformations\DomToArraySimplifier
 
 > Simplify a DOMDocument to an array.
@@ -547,6 +549,17 @@
 | Visibility | Function |
 |:-----------|:---------|
 | public | <strong>overrideRestructure(</strong><em>mixed</em> <strong>$structuredOutput</strong>, <em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>mixed</em><br /><em>Select data to use directly from the structured output, before the restructure operation has been executed.</em> |
+
+<hr /> 
+### Class: \Consolidation\OutputFormatters\Transformations\PropertyListTableTransformation
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>getOriginalData()</strong> : <em>mixed</em> |
+
+*This class extends [\Consolidation\OutputFormatters\Transformations\TableTransformation](#class-consolidationoutputformatterstransformationstabletransformation)*
+
+*This class implements [\Consolidation\OutputFormatters\StructuredData\OriginalDataInterface](#interface-consolidationoutputformattersstructureddataoriginaldatainterface), [\Consolidation\OutputFormatters\StructuredData\TableDataInterface](#interface-consolidationoutputformattersstructureddatatabledatainterface), \IteratorAggregate, \Traversable, \ArrayAccess, \Serializable, \Countable*
 
 <hr /> 
 ### Class: \Consolidation\OutputFormatters\Transformations\PropertyParser

--- a/src/Formatters/CsvFormatter.php
+++ b/src/Formatters/CsvFormatter.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  * Display the provided structured data in a comma-separated list. If
  * there are multiple records provided, then they will be printed
  * one per line.  The primary data types accepted are RowsOfFields and
- * AssociativeList. The later behaves exactly like the former, save for
+ * PropertyList. The later behaves exactly like the former, save for
  * the fact that it contains but a single row. This formmatter can also
  * accept a PHP array; this is also interpreted as a single-row of data
  * with no header.
@@ -29,7 +29,7 @@ class CsvFormatter implements FormatterInterface, ValidDataTypesInterface, Rende
         return
             [
                 new \ReflectionClass('\Consolidation\OutputFormatters\StructuredData\RowsOfFields'),
-                new \ReflectionClass('\Consolidation\OutputFormatters\StructuredData\AssociativeList'),
+                new \ReflectionClass('\Consolidation\OutputFormatters\StructuredData\PropertyList'),
                 new \ReflectionClass('\ArrayObject'),
             ];
     }
@@ -37,7 +37,7 @@ class CsvFormatter implements FormatterInterface, ValidDataTypesInterface, Rende
     public function validate($structuredData)
     {
         // If the provided data was of class RowsOfFields
-        // or AssociativeList, it will be converted into
+        // or PropertyList, it will be converted into
         // a TableTransformation object.
         if (!is_array($structuredData) && (!$structuredData instanceof TableTransformation)) {
             throw new IncompatibleDataException(

--- a/src/Formatters/ListFormatter.php
+++ b/src/Formatters/ListFormatter.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  * This formatter prints a plain, unadorned list of data,
  * with each data item appearing on a separate line.  If you
  * wish your list to contain headers, then use the table
- * formatter, and wrap your data in an AssociativeList.
+ * formatter, and wrap your data in an PropertyList.
  */
 class ListFormatter implements FormatterInterface, OverrideRestructureInterface, RenderDataInterface
 {

--- a/src/Formatters/SectionsFormatter.php
+++ b/src/Formatters/SectionsFormatter.php
@@ -10,7 +10,7 @@ use Consolidation\OutputFormatters\Validate\ValidDataTypesTrait;
 use Consolidation\OutputFormatters\StructuredData\TableDataInterface;
 use Consolidation\OutputFormatters\Transformations\ReorderFields;
 use Consolidation\OutputFormatters\Exception\IncompatibleDataException;
-use Consolidation\OutputFormatters\StructuredData\AssociativeList;
+use Consolidation\OutputFormatters\StructuredData\PropertyList;
 
 /**
  * Display sections of data.
@@ -39,7 +39,7 @@ class SectionsFormatter implements FormatterInterface, ValidDataTypesInterface, 
     public function validate($structuredData)
     {
         // If the provided data was of class RowsOfFields
-        // or AssociativeList, it will be converted into
+        // or PropertyList, it will be converted into
         // a TableTransformation object by the restructure call.
         if (!$structuredData instanceof TableDataInterface) {
             throw new IncompatibleDataException(
@@ -62,7 +62,7 @@ class SectionsFormatter implements FormatterInterface, ValidDataTypesInterface, 
             $rowLabel = $tableTransformer->getRowLabel($rowid);
             $output->writeln('');
             $output->writeln($rowLabel);
-            $sectionData = new AssociativeList($row);
+            $sectionData = new PropertyList($row);
             $sectionOptions = new FormatterOptions([], $options->getOptions());
             $sectionTableTransformer = $sectionData->restructure($sectionOptions);
             $table->setRows($sectionTableTransformer->getTableData(true));

--- a/src/Formatters/TableFormatter.php
+++ b/src/Formatters/TableFormatter.php
@@ -16,7 +16,7 @@ use Consolidation\OutputFormatters\Exception\IncompatibleDataException;
  * Display a table of data with the Symfony Table class.
  *
  * This formatter takes data of either the RowsOfFields or
- * AssociativeList data type.  Tables can be rendered with the
+ * PropertyList data type.  Tables can be rendered with the
  * rows running either vertically (the normal orientation) or
  * horizontally.  By default, associative lists will be displayed
  * as two columns, with the key in the first column and the
@@ -39,7 +39,7 @@ class TableFormatter implements FormatterInterface, ValidDataTypesInterface, Ren
         return
             [
                 new \ReflectionClass('\Consolidation\OutputFormatters\StructuredData\RowsOfFields'),
-                new \ReflectionClass('\Consolidation\OutputFormatters\StructuredData\AssociativeList')
+                new \ReflectionClass('\Consolidation\OutputFormatters\StructuredData\PropertyList')
             ];
     }
 
@@ -49,7 +49,7 @@ class TableFormatter implements FormatterInterface, ValidDataTypesInterface, Ren
     public function validate($structuredData)
     {
         // If the provided data was of class RowsOfFields
-        // or AssociativeList, it will be converted into
+        // or PropertyList, it will be converted into
         // a TableTransformation object by the restructure call.
         if (!$structuredData instanceof TableDataInterface) {
             throw new IncompatibleDataException(

--- a/src/Formatters/XmlFormatter.php
+++ b/src/Formatters/XmlFormatter.php
@@ -17,7 +17,7 @@ use Consolidation\OutputFormatters\StructuredData\Xml\DomDataInterface;
  * Display a table of data with the Symfony Table class.
  *
  * This formatter takes data of either the RowsOfFields or
- * AssociativeList data type.  Tables can be rendered with the
+ * PropertyList data type.  Tables can be rendered with the
  * rows running either vertically (the normal orientation) or
  * horizontally.  By default, associative lists will be displayed
  * as two columns, with the key in the first column and the

--- a/src/StructuredData/AssociativeList.php
+++ b/src/StructuredData/AssociativeList.php
@@ -1,58 +1,12 @@
 <?php
 namespace Consolidation\OutputFormatters\StructuredData;
 
-use Consolidation\OutputFormatters\Options\FormatterOptions;
-use Consolidation\OutputFormatters\StructuredData\ListDataInterface;
-use Consolidation\OutputFormatters\Transformations\PropertyParser;
-use Consolidation\OutputFormatters\Transformations\ReorderFields;
-use Consolidation\OutputFormatters\Transformations\TableTransformation;
-use Consolidation\OutputFormatters\Transformations\AssociativeListTableTransformation;
-
 /**
- * Holds an array where each element of the array is one
- * key : value pair.  The keys must be unique, as is typically
- * the case for associative arrays.
+ * Old name for PropertyList class.
+ *
+ * @deprecated
  */
-class AssociativeList extends AbstractStructuredList
+class AssociativeList extends PropertyList
 {
-    /**
-     * Restructure this data for output by converting it into a table
-     * transformation object.
-     *
-     * @param FormatterOptions $options Options that affect output formatting.
-     * @return Consolidation\OutputFormatters\Transformations\TableTransformation
-     */
-    public function restructure(FormatterOptions $options)
-    {
-        $data = [$this->getArrayCopy()];
-        $options->setConfigurationDefault('list-orientation', true);
-        $tableTransformer = $this->createTableTransformation($data, $options);
-        return $tableTransformer;
-    }
 
-    public function getListData(FormatterOptions $options)
-    {
-        $data = $this->getArrayCopy();
-
-        $defaults = $this->defaultOptions();
-        $fieldLabels = $this->getReorderedFieldLabels([$data], $options, $defaults);
-
-        $result = [];
-        foreach ($fieldLabels as $id => $label) {
-            $result[$id] = $data[$id];
-        }
-        return $result;
-    }
-
-    protected function defaultOptions()
-    {
-        return [
-            FormatterOptions::LIST_ORIENTATION => true,
-        ] + parent::defaultOptions();
-    }
-
-    protected function instantiateTableTransformation($data, $fieldLabels, $rowLabels)
-    {
-        return new AssociativeListTableTransformation($data, $fieldLabels, $rowLabels);
-    }
 }

--- a/src/StructuredData/PropertyList.php
+++ b/src/StructuredData/PropertyList.php
@@ -1,0 +1,58 @@
+<?php
+namespace Consolidation\OutputFormatters\StructuredData;
+
+use Consolidation\OutputFormatters\Options\FormatterOptions;
+use Consolidation\OutputFormatters\StructuredData\ListDataInterface;
+use Consolidation\OutputFormatters\Transformations\PropertyParser;
+use Consolidation\OutputFormatters\Transformations\ReorderFields;
+use Consolidation\OutputFormatters\Transformations\TableTransformation;
+use Consolidation\OutputFormatters\Transformations\PropertyListTableTransformation;
+
+/**
+ * Holds an array where each element of the array is one
+ * key : value pair.  The keys must be unique, as is typically
+ * the case for associative arrays.
+ */
+class PropertyList extends AbstractStructuredList
+{
+    /**
+     * Restructure this data for output by converting it into a table
+     * transformation object.
+     *
+     * @param FormatterOptions $options Options that affect output formatting.
+     * @return Consolidation\OutputFormatters\Transformations\TableTransformation
+     */
+    public function restructure(FormatterOptions $options)
+    {
+        $data = [$this->getArrayCopy()];
+        $options->setConfigurationDefault('list-orientation', true);
+        $tableTransformer = $this->createTableTransformation($data, $options);
+        return $tableTransformer;
+    }
+
+    public function getListData(FormatterOptions $options)
+    {
+        $data = $this->getArrayCopy();
+
+        $defaults = $this->defaultOptions();
+        $fieldLabels = $this->getReorderedFieldLabels([$data], $options, $defaults);
+
+        $result = [];
+        foreach ($fieldLabels as $id => $label) {
+            $result[$id] = $data[$id];
+        }
+        return $result;
+    }
+
+    protected function defaultOptions()
+    {
+        return [
+            FormatterOptions::LIST_ORIENTATION => true,
+        ] + parent::defaultOptions();
+    }
+
+    protected function instantiateTableTransformation($data, $fieldLabels, $rowLabels)
+    {
+        return new PropertyListTableTransformation($data, $fieldLabels, $rowLabels);
+    }
+}

--- a/src/Transformations/PropertyListTableTransformation.php
+++ b/src/Transformations/PropertyListTableTransformation.php
@@ -1,7 +1,7 @@
 <?php
 namespace Consolidation\OutputFormatters\Transformations;
 
-class AssociativeListTableTransformation extends TableTransformation
+class PropertyListTableTransformation extends TableTransformation
 {
     public function getOriginalData()
     {

--- a/tests/src/PropertyListWithCsvCells.php
+++ b/tests/src/PropertyListWithCsvCells.php
@@ -2,10 +2,10 @@
 namespace Consolidation\TestUtils;
 
 use Consolidation\OutputFormatters\Options\FormatterOptions;
-use Consolidation\OutputFormatters\StructuredData\AssociativeList;
+use Consolidation\OutputFormatters\StructuredData\PropertyList;
 use Consolidation\OutputFormatters\StructuredData\RenderCellInterface;
 
-class AssociativeListWithCsvCells extends AssociativeList implements RenderCellInterface
+class PropertyListWithCsvCells extends PropertyList implements RenderCellInterface
 {
     public function renderCell($key, $cellData, FormatterOptions $options, $rowData)
     {

--- a/tests/testFormatters.php
+++ b/tests/testFormatters.php
@@ -1,11 +1,12 @@
 <?php
 namespace Consolidation\OutputFormatters;
 
-use Consolidation\TestUtils\AssociativeListWithCsvCells;
+use Consolidation\TestUtils\PropertyListWithCsvCells;
 use Consolidation\TestUtils\RowsOfFieldsWithAlternatives;
 use Consolidation\OutputFormatters\Options\FormatterOptions;
-use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 use Consolidation\OutputFormatters\StructuredData\AssociativeList;
+use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
+use Consolidation\OutputFormatters\StructuredData\PropertyList;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputInterface;
@@ -334,7 +335,7 @@ EOT;
     /**
      * @expectedException \Consolidation\OutputFormatters\Exception\IncompatibleDataException
      * @expectedExceptionCode 1
-     * @expectedExceptionMessage Data provided to Consolidation\OutputFormatters\Formatters\CsvFormatter must be one of an instance of Consolidation\OutputFormatters\StructuredData\RowsOfFields, an instance of Consolidation\OutputFormatters\StructuredData\AssociativeList or an array. Instead, a string was provided.
+     * @expectedExceptionMessage Data provided to Consolidation\OutputFormatters\Formatters\CsvFormatter must be one of an instance of Consolidation\OutputFormatters\StructuredData\RowsOfFields, an instance of Consolidation\OutputFormatters\StructuredData\PropertyList or an array. Instead, a string was provided.
      */
     function testBadDataTypeForCsv()
     {
@@ -837,6 +838,17 @@ EOT;
             'two' => 'banana',
             'three' => 'carrot',
         ];
+        return new PropertyList($data);
+    }
+
+    // Test with the deprecated data structure
+    protected function simpleListExampleDataUsingAssociativeList()
+    {
+        $data = [
+            'one' => 'apple',
+            'two' => 'banana',
+            'three' => 'carrot',
+        ];
         return new AssociativeList($data);
     }
 
@@ -870,7 +882,6 @@ EOT;
 
     function testSimpleList()
     {
-        $data = $this->simpleListExampleData();
 
         $expected = <<<EOT
  ------- --------
@@ -879,6 +890,12 @@ EOT;
   Three   carrot
  ------- --------
 EOT;
+        $data = $this->simpleListExampleDataUsingAssociativeList();
+
+        $this->assertFormattedOutputMatches($expected, 'table', $data);
+
+        $data = $this->simpleListExampleData();
+
         $this->assertFormattedOutputMatches($expected, 'table', $data);
 
         $expected = <<<EOT
@@ -960,7 +977,7 @@ EOT;
             'three' => 'carrot',
             'four' => ['peaches', 'pumpkin pie'],
         ];
-        $list = new AssociativeList($data);
+        $list = new PropertyList($data);
 
         $list->addRendererFunction(
             function ($key, $cellData, FormatterOptions $options)
@@ -983,16 +1000,16 @@ EOT;
             'three' => 'carrot',
             'four' => ['peaches', 'pumpkin pie'],
         ];
-        return new AssociativeListWithCsvCells($data);
+        return new PropertyListWithCsvCells($data);
     }
 
-    function testAssociativeListWithCsvCells()
+    function testPropertyListWithCsvCells()
     {
-        $this->doAssociativeListWithCsvCells($this->associativeListWithRenderer());
-        $this->doAssociativeListWithCsvCells($this->associativeListWithCsvCells());
+        $this->doPropertyListWithCsvCells($this->associativeListWithRenderer());
+        $this->doPropertyListWithCsvCells($this->associativeListWithCsvCells());
     }
 
-    function doAssociativeListWithCsvCells($data)
+    function doPropertyListWithCsvCells($data)
     {
         $expected = <<<EOT
  ------- ---------------------

--- a/tests/testIncompatibleData.php
+++ b/tests/testIncompatibleData.php
@@ -2,7 +2,7 @@
 namespace Consolidation\OutputFormatters;
 
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
-use Consolidation\OutputFormatters\StructuredData\AssociativeList;
+use Consolidation\OutputFormatters\StructuredData\PropertyList;
 use Consolidation\OutputFormatters\Exception\IncompatibleDataException;
 
 class IncompatibleDataTests extends \PHPUnit_Framework_TestCase
@@ -23,10 +23,10 @@ class IncompatibleDataTests extends \PHPUnit_Framework_TestCase
     {
         $tableFormatter = $this->formatterManager->getFormatter('table');
 
-        $this->assertIncompatibleDataMessage('Data provided to Consolidation\OutputFormatters\Formatters\TableFormatter must be either an instance of Consolidation\OutputFormatters\StructuredData\RowsOfFields or an instance of Consolidation\OutputFormatters\StructuredData\AssociativeList. Instead, a string was provided.', $tableFormatter, 'a string');
-        $this->assertIncompatibleDataMessage('Data provided to Consolidation\OutputFormatters\Formatters\TableFormatter must be either an instance of Consolidation\OutputFormatters\StructuredData\RowsOfFields or an instance of Consolidation\OutputFormatters\StructuredData\AssociativeList. Instead, an instance of Consolidation\OutputFormatters\FormatterManager was provided.', $tableFormatter, $this->formatterManager);
-        $this->assertIncompatibleDataMessage('Data provided to Consolidation\OutputFormatters\Formatters\TableFormatter must be either an instance of Consolidation\OutputFormatters\StructuredData\RowsOfFields or an instance of Consolidation\OutputFormatters\StructuredData\AssociativeList. Instead, an array was provided.', $tableFormatter, []);
-        $this->assertIncompatibleDataMessage('Data provided to Consolidation\OutputFormatters\Formatters\TableFormatter must be either an instance of Consolidation\OutputFormatters\StructuredData\RowsOfFields or an instance of Consolidation\OutputFormatters\StructuredData\AssociativeList. Instead, an instance of Consolidation\OutputFormatters\StructuredData\AssociativeList was provided.', $tableFormatter, new AssociativeList([]));
+        $this->assertIncompatibleDataMessage('Data provided to Consolidation\OutputFormatters\Formatters\TableFormatter must be either an instance of Consolidation\OutputFormatters\StructuredData\RowsOfFields or an instance of Consolidation\OutputFormatters\StructuredData\PropertyList. Instead, a string was provided.', $tableFormatter, 'a string');
+        $this->assertIncompatibleDataMessage('Data provided to Consolidation\OutputFormatters\Formatters\TableFormatter must be either an instance of Consolidation\OutputFormatters\StructuredData\RowsOfFields or an instance of Consolidation\OutputFormatters\StructuredData\PropertyList. Instead, an instance of Consolidation\OutputFormatters\FormatterManager was provided.', $tableFormatter, $this->formatterManager);
+        $this->assertIncompatibleDataMessage('Data provided to Consolidation\OutputFormatters\Formatters\TableFormatter must be either an instance of Consolidation\OutputFormatters\StructuredData\RowsOfFields or an instance of Consolidation\OutputFormatters\StructuredData\PropertyList. Instead, an array was provided.', $tableFormatter, []);
+        $this->assertIncompatibleDataMessage('Data provided to Consolidation\OutputFormatters\Formatters\TableFormatter must be either an instance of Consolidation\OutputFormatters\StructuredData\RowsOfFields or an instance of Consolidation\OutputFormatters\StructuredData\PropertyList. Instead, an instance of Consolidation\OutputFormatters\StructuredData\PropertyList was provided.', $tableFormatter, new PropertyList([]));
     }
 
     /**
@@ -42,7 +42,7 @@ class IncompatibleDataTests extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Exception
-     * @expectedExceptionMessage Data provided to Consolidation\OutputFormatters\Formatters\TableFormatter must be either an instance of Consolidation\OutputFormatters\StructuredData\RowsOfFields or an instance of Consolidation\OutputFormatters\StructuredData\AssociativeList. Instead, a string was provided.
+     * @expectedExceptionMessage Data provided to Consolidation\OutputFormatters\Formatters\TableFormatter must be either an instance of Consolidation\OutputFormatters\StructuredData\RowsOfFields or an instance of Consolidation\OutputFormatters\StructuredData\PropertyList. Instead, a string was provided.
      */
     public function testInvalidTableData()
     {

--- a/tests/testValidFormats.php
+++ b/tests/testValidFormats.php
@@ -3,7 +3,7 @@ namespace Consolidation\OutputFormatters;
 
 use Consolidation\OutputFormatters\Options\FormatterOptions;
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
-use Consolidation\OutputFormatters\StructuredData\AssociativeList;
+use Consolidation\OutputFormatters\StructuredData\PropertyList;
 
 class ValidFormatsTests extends \PHPUnit_Framework_TestCase
 {
@@ -18,7 +18,7 @@ class ValidFormatsTests extends \PHPUnit_Framework_TestCase
     function testValidFormats()
     {
         $arrayObjectRef = new \ReflectionClass('\ArrayObject');
-        $associativeListRef = new \ReflectionClass('\Consolidation\OutputFormatters\StructuredData\AssociativeList');
+        $associativeListRef = new \ReflectionClass('\Consolidation\OutputFormatters\StructuredData\PropertyList');
         $rowsOfFieldsRef = new \ReflectionClass('\Consolidation\OutputFormatters\StructuredData\RowsOfFields');
         $notADataType = new \ReflectionClass('\Consolidation\OutputFormatters\FormatterManager');
 
@@ -52,7 +52,7 @@ class ValidFormatsTests extends \PHPUnit_Framework_TestCase
         $validFormats = $this->formatterManager->validFormats([]);
         $this->assertEquals('csv,json,list,php,print-r,string,tsv,var_export,xml,yaml', implode(',', $validFormats));
 
-        // Check to see which formats can handle an AssociativeList
+        // Check to see which formats can handle an PropertyList
         $validFormats = $this->formatterManager->validFormats($associativeListRef);
         $this->assertEquals('csv,json,list,php,print-r,string,table,tsv,var_export,xml,yaml', implode(',', $validFormats));
 


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [X] Has tests that cover changes

### Summary
The name `AssociativeList` seemed to be the source of confusion, so this has been renamed to `PropertyList`.
