### PR TITLE
Add word wrapping to table formatter.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -43,6 +43,7 @@
 - [\Consolidation\OutputFormatters\Transformations\ReorderFields](#class-consolidationoutputformatterstransformationsreorderfields)
 - [\Consolidation\OutputFormatters\Transformations\SimplifyToArrayInterface (interface)](#interface-consolidationoutputformatterstransformationssimplifytoarrayinterface)
 - [\Consolidation\OutputFormatters\Transformations\TableTransformation](#class-consolidationoutputformatterstransformationstabletransformation)
+- [\Consolidation\OutputFormatters\Transformations\WordWrapper](#class-consolidationoutputformatterstransformationswordwrapper)
 - [\Consolidation\OutputFormatters\Validate\ValidationInterface (interface)](#interface-consolidationoutputformattersvalidatevalidationinterface)
 - [\Consolidation\OutputFormatters\Validate\ValidDataTypesInterface (interface)](#interface-consolidationoutputformattersvalidatevaliddatatypesinterface)
 
@@ -266,7 +267,9 @@
 | public | <strong>validDataTypes()</strong> : <em>void</em> |
 | public | <strong>validate(</strong><em>mixed</em> <strong>$structuredData</strong>)</strong> : <em>mixed</em><br /><em>Throw an IncompatibleDataException if the provided data cannot be processed by this formatter.  Return the source data if it is valid. The data may be encapsulated or converted if necessary.</em> |
 | public | <strong>write(</strong><em>\Symfony\Component\Console\Output\OutputInterface</em> <strong>$output</strong>, <em>mixed</em> <strong>$data</strong>, <em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>string</em><br /><em>Given structured data, apply appropriate formatting, and return a printable string.</em> |
+| protected static | <strong>addCustomTableStyles(</strong><em>mixed</em> <strong>$table</strong>)</strong> : <em>void</em><br /><em>Add our custom table style(s) to the table.</em> |
 | protected | <strong>renderEachCell(</strong><em>mixed</em> <strong>$originalData</strong>, <em>mixed</em> <strong>$restructuredData</strong>, <em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>void</em> |
+| protected | <strong>wrap(</strong><em>array</em> <strong>$data</strong>, <em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>array</em><br /><em>Wrap the table data</em> |
 
 *This class implements [\Consolidation\OutputFormatters\Formatters\FormatterInterface](#interface-consolidationoutputformattersformattersformatterinterface), [\Consolidation\OutputFormatters\Validate\ValidDataTypesInterface](#interface-consolidationoutputformattersvalidatevaliddatatypesinterface), [\Consolidation\OutputFormatters\Validate\ValidationInterface](#interface-consolidationoutputformattersvalidatevalidationinterface), [\Consolidation\OutputFormatters\Formatters\RenderDataInterface](#interface-consolidationoutputformattersformattersrenderdatainterface)*
 
@@ -352,6 +355,7 @@
 | public | <strong>setOptions(</strong><em>array</em> <strong>$options</strong>)</strong> : <em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em><br /><em>Set all of the options that were specified by the user for this request.</em> |
 | public | <strong>setRowLabels(</strong><em>mixed</em> <strong>$rowLabels</strong>)</strong> : <em>void</em> |
 | public | <strong>setTableStyle(</strong><em>mixed</em> <strong>$style</strong>)</strong> : <em>void</em> |
+| public | <strong>setWidth(</strong><em>mixed</em> <strong>$width</strong>)</strong> : <em>void</em> |
 | protected | <strong>defaultsForKey(</strong><em>string</em> <strong>$key</strong>, <em>array</em> <strong>$defaults</strong>, <em>bool</em> <strong>$default=false</strong>)</strong> : <em>array</em><br /><em>Reduce provided defaults to the single item identified by '$key', if it exists, or an empty array otherwise.</em> |
 | protected | <strong>fetch(</strong><em>string</em> <strong>$key</strong>, <em>array</em> <strong>$defaults=array()</strong>, <em>bool/mixed</em> <strong>$default=false</strong>)</strong> : <em>mixed</em><br /><em>Look up a key, and return its raw value.</em> |
 | protected | <strong>fetchRawValues(</strong><em>array</em> <strong>$defaults=array()</strong>)</strong> : <em>array</em><br /><em>Look up all of the items associated with the provided defaults.</em> |
@@ -615,6 +619,16 @@
 *This class extends \ArrayObject*
 
 *This class implements \Countable, \Serializable, \ArrayAccess, \Traversable, \IteratorAggregate, [\Consolidation\OutputFormatters\StructuredData\TableDataInterface](#interface-consolidationoutputformattersstructureddatatabledatainterface), [\Consolidation\OutputFormatters\StructuredData\OriginalDataInterface](#interface-consolidationoutputformattersstructureddataoriginaldatainterface)*
+
+<hr /> 
+### Class: \Consolidation\OutputFormatters\Transformations\WordWrapper
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>__construct(</strong><em>mixed</em> <strong>$width</strong>)</strong> : <em>void</em> |
+| public | <strong>wrap(</strong><em>mixed</em> <strong>$rows</strong>, <em>array</em> <strong>$widths=array()</strong>)</strong> : <em>array</em><br /><em>Wrap the cells in each part of the provided data table</em> |
+| protected | <strong>columnAutowidth(</strong><em>array</em> <strong>$rows</strong>, <em>array</em> <strong>$widths</strong>)</strong> : <em>void</em><br /><em>Determine the best fit for column widths. Ported from Drush. (in characters) - these will be left as is.</em> |
+| protected | <strong>wrapCell(</strong><em>mixed</em> <strong>$cell</strong>, <em>string</em> <strong>$cellWidth</strong>)</strong> : <em>mixed</em><br /><em>Wrap one cell.  Guard against modifying non-strings and then call through to wordwrap().</em> |
 
 <hr /> 
 ### Interface: \Consolidation\OutputFormatters\Validate\ValidationInterface

--- a/src/Options/FormatterOptions.php
+++ b/src/Options/FormatterOptions.php
@@ -46,6 +46,7 @@ class FormatterOptions
     const DEFAULT_FIELDS = 'default-fields';
     const DEFAULT_STRING_FIELD = 'default-string-field';
     const DELIMITER = 'delimiter';
+    const TERMINAL_WIDTH = 'width';
 
     /**
      * Create a new FormatterOptions with the configuration data and the
@@ -110,6 +111,11 @@ class FormatterOptions
     public function setDefaultStringField($defaultStringField)
     {
         return $this->setConfigurationValue(self::DEFAULT_STRING_FIELD, $defaultStringField);
+    }
+
+    public function setWidth($width)
+    {
+        return $this->setConfigurationValue(self::TERMINAL_WIDTH, $width);
     }
 
     /**

--- a/src/Transformations/WordWrapper.php
+++ b/src/Transformations/WordWrapper.php
@@ -1,0 +1,138 @@
+<?php
+namespace Consolidation\OutputFormatters\Transformations;
+
+class WordWrapper
+{
+    protected $width;
+
+    public function __construct($width)
+    {
+        $this->width = $width;
+    }
+
+    /**
+     * Wrap the cells in each part of the provided data table
+     * @param array $rows
+     * @return array
+     */
+    public function wrap($rows, $widths = [])
+    {
+        // If the width was not set, then disable wordwrap.
+        if (!$this->width) {
+            return $rows;
+        }
+
+        // Calculate the column widths to use based on the content.
+        $auto_widths = $this->columnAutowidth($rows, $widths);
+
+        // Do wordwrap on all cells.
+        $newrows = array();
+        foreach ($rows as $rowkey => $row) {
+            foreach ($row as $colkey => $cell) {
+                $newrows[$rowkey][$colkey] = $this->wrapCell($cell, $auto_widths[$colkey]);
+            }
+        }
+
+        return $newrows;
+    }
+
+    /**
+     * Wrap one cell.  Guard against modifying non-strings and
+     * then call through to wordwrap().
+     *
+     * @param mixed $cell
+     * @param string $cellWidth
+     * @return mixed
+     */
+    protected function wrapCell($cell, $cellWidth)
+    {
+        if (!is_string($cell)) {
+            return $cell;
+        }
+        return wordwrap($cell, $cellWidth, "\n", true);
+    }
+
+    /**
+     * Determine the best fit for column widths. Ported from Drush.
+     *
+     * @param array $rows The rows to use for calculations.
+     * @param array $widths Manually specified widths of each column
+     *   (in characters) - these will be left as is.
+     */
+    protected function columnAutowidth($rows, $widths)
+    {
+        $auto_widths = $widths;
+
+        // First we determine the distribution of row lengths in each column.
+        // This is an array of descending character length keys (i.e. starting at
+        // the rightmost character column), with the value indicating the number
+        // of rows where that character column is present.
+        $col_dist = array();
+        foreach ($rows as $rowkey => $row) {
+            foreach ($row as $col_id => $cell) {
+                if (empty($widths[$col_id])) {
+                    $length = strlen($cell);
+                    if ($length == 0) {
+                        $col_dist[$col_id][0] = 0;
+                    }
+                    while ($length > 0) {
+                        if (!isset($col_dist[$col_id][$length])) {
+                            $col_dist[$col_id][$length] = 0;
+                        }
+                        $col_dist[$col_id][$length]++;
+                        $length--;
+                    }
+                }
+            }
+        }
+        foreach ($col_dist as $col_id => $count) {
+            // Sort the distribution in decending key order.
+            krsort($col_dist[$col_id]);
+            // Initially we set all columns to their "ideal" longest width
+            // - i.e. the width of their longest column.
+            $auto_widths[$col_id] = max(array_keys($col_dist[$col_id]));
+        }
+
+        // We determine what width we have available to use, and what width the
+        // above "ideal" columns take up.
+        $available_width = $this->width - (count($auto_widths) * 2);
+        $auto_width_current = array_sum($auto_widths);
+
+        // If we need to reduce a column so that we can fit the space we use this
+        // loop to figure out which column will cause the "least wrapping",
+        // (relative to the other columns) and reduce the width of that column.
+        while ($auto_width_current > $available_width) {
+            $count = 0;
+            $width = 0;
+            foreach ($col_dist as $col_id => $counts) {
+                // If we are just starting out, select the first column.
+                if ($count == 0 ||
+                 // OR: if this column would cause less wrapping than the currently
+                 // selected column, then select it.
+                 (current($counts) < $count) ||
+                 // OR: if this column would cause the same amount of wrapping, but is
+                 // longer, then we choose to wrap the longer column (proportionally
+                 // less wrapping, and helps avoid triple line wraps).
+                 (current($counts) == $count && key($counts) > $width)) {
+                    // Select the column number, and record the count and current width
+                    // for later comparisons.
+                    $column = $col_id;
+                    $count = current($counts);
+                    $width = key($counts);
+                }
+            }
+            if ($width <= 1) {
+                // If we have reached a width of 1 then give up, so wordwrap can still progress.
+                break;
+            }
+            // Reduce the width of the selected column.
+            $auto_widths[$column]--;
+            // Reduce our overall table width counter.
+            $auto_width_current--;
+            // Remove the corresponding data from the disctribution, so next time
+            // around we use the data for the row to the left.
+            unset($col_dist[$column][$width]);
+        }
+        return $auto_widths;
+    }
+}

--- a/tests/testFormatters.php
+++ b/tests/testFormatters.php
@@ -524,6 +524,36 @@ EOT;
         $this->assertFormattedOutputMatches($expectedTsvWithHeaders, 'tsv', $data, new FormatterOptions(), ['include-field-labels' => true]);
     }
 
+    function testTableWithWordWrapping()
+    {
+        $options = new FormatterOptions();
+        $options->setWidth(40);
+
+        $data = [
+            [
+                'first' => 'This is a really long cell that contains a lot of data. When it is rendered, it should be wrapped across multiple lines.',
+                'second' => 'This is the second column of the same table. It is also very long, and should be wrapped across multiple lines, just like the first column.',
+            ]
+        ];
+        $data = new RowsOfFields($data);
+
+        $expected = <<<EOT
+ ------------------- --------------------
+  First               Second
+ ------------------- --------------------
+  This is a really    This is the second
+  long cell that      column of the same
+  contains a lot of   table. It is also
+  data. When it is    very long, and
+  rendered, it        should be wrapped
+  should be wrapped   across multiple
+  across multiple     lines, just like
+  lines.              the first column.
+ ------------------- --------------------
+EOT;
+        $this->assertFormattedOutputMatches($expected, 'table', $data, $options);
+    }
+
     protected function simpleTableExampleData()
     {
         $data = [


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [X] Adds a feature
- [ ] Breaks backwards compatibility
- [X] Has tests that cover changes

### Summary
Add word wrapping to table formatter.

### Description
Ported drush_table_column_autowidth from Drush