### PR TITLE
Fine-tune wordwrap using table style.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -269,7 +269,7 @@
 | public | <strong>write(</strong><em>\Symfony\Component\Console\Output\OutputInterface</em> <strong>$output</strong>, <em>mixed</em> <strong>$data</strong>, <em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>string</em><br /><em>Given structured data, apply appropriate formatting, and return a printable string.</em> |
 | protected static | <strong>addCustomTableStyles(</strong><em>mixed</em> <strong>$table</strong>)</strong> : <em>void</em><br /><em>Add our custom table style(s) to the table.</em> |
 | protected | <strong>renderEachCell(</strong><em>mixed</em> <strong>$originalData</strong>, <em>mixed</em> <strong>$restructuredData</strong>, <em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>void</em> |
-| protected | <strong>wrap(</strong><em>array</em> <strong>$data</strong>, <em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>array</em><br /><em>Wrap the table data</em> |
+| protected | <strong>wrap(</strong><em>array</em> <strong>$data</strong>, <em>\Symfony\Component\Console\Helper\TableStyle</em> <strong>$tableStyle</strong>, <em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>array</em><br /><em>Wrap the table data</em> |
 
 *This class implements [\Consolidation\OutputFormatters\Formatters\FormatterInterface](#interface-consolidationoutputformattersformattersformatterinterface), [\Consolidation\OutputFormatters\Validate\ValidDataTypesInterface](#interface-consolidationoutputformattersvalidatevaliddatatypesinterface), [\Consolidation\OutputFormatters\Validate\ValidationInterface](#interface-consolidationoutputformattersvalidatevalidationinterface), [\Consolidation\OutputFormatters\Formatters\RenderDataInterface](#interface-consolidationoutputformattersformattersrenderdatainterface)*
 
@@ -626,6 +626,7 @@
 | Visibility | Function |
 |:-----------|:---------|
 | public | <strong>__construct(</strong><em>mixed</em> <strong>$width</strong>)</strong> : <em>void</em> |
+| public | <strong>setPaddingFromStyle(</strong><em>\Symfony\Component\Console\Helper\TableStyle</em> <strong>$style</strong>)</strong> : <em>void</em><br /><em>Calculate our padding widths from the specified table style.</em> |
 | public | <strong>wrap(</strong><em>array</em> <strong>$rows</strong>, <em>array</em> <strong>$widths=array()</strong>)</strong> : <em>array</em><br /><em>Wrap the cells in each part of the provided data table</em> |
 | protected | <strong>columnAutowidth(</strong><em>array</em> <strong>$rows</strong>, <em>array</em> <strong>$widths</strong>)</strong> : <em>void</em><br /><em>Determine the best fit for column widths. Ported from Drush. (in characters) - these will be left as is.</em> |
 | protected | <strong>wrapCell(</strong><em>mixed</em> <strong>$cell</strong>, <em>string</em> <strong>$cellWidth</strong>)</strong> : <em>mixed</em><br /><em>Wrap one cell.  Guard against modifying non-strings and then call through to wordwrap().</em> |

--- a/src/Formatters/TableFormatter.php
+++ b/src/Formatters/TableFormatter.php
@@ -84,7 +84,7 @@ class TableFormatter implements FormatterInterface, ValidDataTypesInterface, Ren
             $table->setHeaders($headers);
         }
         $data = $tableTransformer->getTableData($includeHeaders && $isList);
-        $data = $this->wrap($data, $options);
+        $data = $this->wrap($data, $table->getStyle(), $options);
         $table->setRows($data);
         $table->render();
     }
@@ -92,12 +92,14 @@ class TableFormatter implements FormatterInterface, ValidDataTypesInterface, Ren
     /**
      * Wrap the table data
      * @param array $data
+     * @param TableStyle $tableStyle
      * @param FormatterOptions $options
      * @return array
      */
-    protected function wrap($data, FormatterOptions $options)
+    protected function wrap($data, TableStyle $tableStyle, FormatterOptions $options)
     {
         $wrapper = new WordWrapper($options->get(FormatterOptions::TERMINAL_WIDTH));
+        $wrapper->setPaddingFromStyle($tableStyle);
         return $wrapper->wrap($data);
     }
 

--- a/src/Transformations/WordWrapper.php
+++ b/src/Transformations/WordWrapper.php
@@ -1,13 +1,36 @@
 <?php
 namespace Consolidation\OutputFormatters\Transformations;
 
+use Symfony\Component\Console\Helper\TableStyle;
+
 class WordWrapper
 {
     protected $width;
 
+    // For now, hardcode these to match what the Symfony Table helper does.
+    // Note that these might actually need to be adjusted depending on the
+    // table style.
+    protected $extraPaddingAtBeginningOfLine = 0;
+    protected $extraPaddingAtEndOfLine = 0;
+    protected $paddingInEachCell = 3;
+
     public function __construct($width)
     {
         $this->width = $width;
+    }
+
+    /**
+     * Calculate our padding widths from the specified table style.
+     * @param TableStyle $style
+     */
+    public function setPaddingFromStyle(TableStyle $style)
+    {
+        $verticalBorderLen = strlen($style->getVerticalBorderChar());
+        $paddingLen = strlen($style->getPaddingChar());
+
+        $this->extraPaddingAtBeginningOfLine = 0;
+        $this->extraPaddingAtEndOfLine = $verticalBorderLen;
+        $this->paddingInEachCell = $verticalBorderLen + $paddingLen;
     }
 
     /**
@@ -95,7 +118,7 @@ class WordWrapper
 
         // We determine what width we have available to use, and what width the
         // above "ideal" columns take up.
-        $available_width = $this->width - (count($auto_widths) * 2);
+        $available_width = $this->width - ($this->extraPaddingAtBeginningOfLine + $this->extraPaddingAtEndOfLine + (count($auto_widths) * $this->paddingInEachCell));
         $auto_width_current = array_sum($auto_widths);
 
         // If we need to reduce a column so that we can fit the space we use this

--- a/tests/testFormatters.php
+++ b/tests/testFormatters.php
@@ -527,7 +527,7 @@ EOT;
     function testTableWithWordWrapping()
     {
         $options = new FormatterOptions();
-        $options->setWidth(40);
+        $options->setWidth(42);
 
         $data = [
             [


### PR DESCRIPTION
### Overview
This pull request:

- [X] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [X] Has tests that cover changes

### Summary
Wordwrap routine did not property account for Symfony table styling characters.
