### PR TITLE
Fix mishandling of field selection with empty results.

### DIFF
--- a/src/Transformations/ReorderFields.php
+++ b/src/Transformations/ReorderFields.php
@@ -42,6 +42,9 @@ class ReorderFields
     {
         $result = [];
         $firstRow = reset($data);
+        if (!$firstRow) {
+            $firstRow = $fieldLabels;
+        }
         foreach ($fields as $field) {
             if (array_key_exists($field, $firstRow)) {
                 if (array_key_exists($field, $fieldLabels)) {

--- a/tests/testFormatters.php
+++ b/tests/testFormatters.php
@@ -842,6 +842,17 @@ EOT;
  -----
 EOT;
         $this->assertFormattedOutputMatches($expectedSingleField, 'table', $data, $configurationData, ['field' => 'San']);
+
+        $expectedEmptyColumn = <<<EOT
+ -----
+  San
+ -----
+EOT;
+
+        $this->assertFormattedOutputMatches($expectedEmptyColumn, 'table', new RowsOfFields([]), $configurationData, ['field' => 'San']);
+
+        $this->assertFormattedOutputMatches('', '', new RowsOfFields([]), $configurationData, ['field' => 'San']);
+        $this->assertFormattedOutputMatches('[]', 'json', new RowsOfFields([]), $configurationData, ['field' => 'San']);
     }
 
     /**


### PR DESCRIPTION
### Overview
This pull request:

- [X] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [X] Has tests that cover changes

### Summary
Fix handling of field selection when the command result is an empty array.

### Description
If the command result was empty, the field selection would evaluate `$v = reset($data);`. This comes out as a boolean when `$data` is empty, causing an error abort.

This PR correctly handles empty results in field selection, and adds tests to confirm this use-case works correctly.
