### PR TITLE
Typo in CalculateWidths::distributeLongColumns causes failure for some column width distributions.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -92,6 +92,8 @@
 
 *This class extends \Exception*
 
+*This class implements \Throwable*
+
 <hr /> 
 ### Class: \Consolidation\OutputFormatters\Exception\IncompatibleDataException
 
@@ -102,6 +104,8 @@
 | public | <strong>__construct(</strong><em>[\Consolidation\OutputFormatters\Formatters\FormatterInterface](#interface-consolidationoutputformattersformattersformatterinterface)</em> <strong>$formatter</strong>, <em>mixed</em> <strong>$data</strong>, <em>mixed</em> <strong>$allowedTypes</strong>)</strong> : <em>void</em> |
 
 *This class extends [\Consolidation\OutputFormatters\Exception\AbstractDataFormatException](#class-consolidationoutputformattersexceptionabstractdataformatexception-abstract)*
+
+*This class implements \Throwable*
 
 <hr /> 
 ### Class: \Consolidation\OutputFormatters\Exception\InvalidFormatException
@@ -114,6 +118,8 @@
 
 *This class extends [\Consolidation\OutputFormatters\Exception\AbstractDataFormatException](#class-consolidationoutputformattersexceptionabstractdataformatexception-abstract)*
 
+*This class implements \Throwable*
+
 <hr /> 
 ### Class: \Consolidation\OutputFormatters\Exception\UnknownFieldException
 
@@ -125,6 +131,8 @@
 
 *This class extends \Exception*
 
+*This class implements \Throwable*
+
 <hr /> 
 ### Class: \Consolidation\OutputFormatters\Exception\UnknownFormatException
 
@@ -135,6 +143,8 @@
 | public | <strong>__construct(</strong><em>mixed</em> <strong>$format</strong>)</strong> : <em>void</em> |
 
 *This class extends \Exception*
+
+*This class implements \Throwable*
 
 <hr /> 
 ### Class: \Consolidation\OutputFormatters\Formatters\CsvFormatter
@@ -701,7 +711,7 @@
 
 | Visibility | Function |
 |:-----------|:---------|
-| public | <strong>validDataTypes()</strong> : <em>[\ReflectionClass](http://php.net/manual/en/class.reflectionclass.php)[]</em><br /><em>Return the list of data types acceptable to this formatter</em> |
+| public | <strong>validDataTypes()</strong> : <em>[\ReflectionClass[]](http://php.net/manual/en/class.reflectionclass.php)</em><br /><em>Return the list of data types acceptable to this formatter</em> |
 
 *This class implements [\Consolidation\OutputFormatters\Validate\ValidationInterface](#interface-consolidationoutputformattersvalidatevalidationinterface)*
 

--- a/src/Transformations/Wrap/CalculateWidths.php
+++ b/src/Transformations/Wrap/CalculateWidths.php
@@ -119,7 +119,7 @@ class CalculateWidths
 
         // Take out the columns that are too small and redistribute the rest.
         $availableWidth -= $undersized->totalWidth();
-        $remaining = $dataWidths->removeColumns($undersized);
+        $remaining = $dataWidths->removeColumns($undersized->keys());
         $distributeRemaining = $this->distributeLongColumns($availableWidth, $remaining, $minimumWidths);
 
         return $undersized->combine($distributeRemaining);

--- a/tests/testFormatters.php
+++ b/tests/testFormatters.php
@@ -567,6 +567,54 @@ EOT;
         $this->assertFormattedOutputMatches($expected, 'table', $data, $options);
     }
 
+    function testWrappingLotsOfColumns()
+    {
+        $options = new FormatterOptions();
+
+        $data = [
+            [
+                'id' => '4d87b545-b4c3-4ece-9908-20c5c5e67e81',
+                'name' => '123456781234567812345678123456781234567812345678',
+                'service_level' => 'business',
+                'framework' => 'wordpress-network',
+                'owner' => '8558a08d-8059-45f6-9c4b-908299a025ee',
+                'created' => '2017-05-24 19:28:45',
+                'memberships' => 'b3a42ba5-755d-42ca-9109-21bde32809d0: Team,9bfaaf50-ece3-4460-acb8-dc1b8dd536e8: pantheon-engineering-canary-sites',
+                'frozen' => 'false',
+            ],
+            [
+                'id' => '3d87b545-b4c3-4ece-9908-20c5c5e67e80',
+                'name' => 'build-tools-136',
+                'service_level' => 'free',
+                'framework' => 'drupal8',
+                'owner' => '7558a08d-8059-45f6-9c4b-908299a025ef',
+                'created' => '2017-05-24 19:28:45',
+                'memberships' => '5ae1fa30-8cc4-4894-8ca9-d50628dcba17: ci-for-drupal-8-composer',
+                'frozen' => 'false',
+            ]
+        ];
+        $data = new RowsOfFields($data);
+
+        $expected = <<<EOT
+ ------------- ---------------- --------------- ----------- ------------- --------- ------------------------------------ --------
+  Id            Name             Service_level   Framework   Owner         Created   Memberships                          Frozen
+ ------------- ---------------- --------------- ----------- ------------- --------- ------------------------------------ --------
+  4d87b545-b4   12345678123456   business        wordp       8558a08d-80   2017-0    b3a42ba5-755d-42ca-9109-21bde32809   false
+  c3-4ece-990   78123456781234                   ress-       59-45f6-9c4   5-24      d0:
+  8-20c5c5e67   56781234567812                   netwo       b-908299a02   19:28:    Team,9bfaaf50-ece3-4460-acb8-dc1b8
+  e81           345678                           rk          5ee           45        dd536e8:
+                                                                                     pantheon-engineering-canary-sites
+  3d87b545-b4   build-tools-13   free            drupa       7558a08d-80   2017-0    5ae1fa30-8cc4-4894-8ca9-d50628dcba   false
+  c3-4ece-990   6                                l8          59-45f6-9c4   5-24      17: ci-for-drupal-8-composer
+  8-20c5c5e67                                                b-908299a02   19:28:
+  e80                                                        5ef           45
+ ------------- ---------------- --------------- ----------- ------------- --------- ------------------------------------ --------
+EOT;
+
+        $options->setWidth(125);
+        $this->assertFormattedOutputMatches($expected, 'table', $data, $options);
+    }
+
     function testTableWithWordWrapping2()
     {
         $options = new FormatterOptions();


### PR DESCRIPTION
Fixes https://github.com/pantheon-systems/terminus/issues/1701.

### Overview
This pull request:

- [X] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [X] Has tests that cover changes

### Summary
Simple typo in seldom-needed code causes a blow-up.

The untested part of the function iteratively refines the column width distributions only in cases where the first pass doesn't get the best distribution. However, this rarely happens, so this code was not covered by tests.  Added a carefully-contrived test to ensure this code is covered by tests.
