### PR TITLE
Allow XML output for RowsOfFields

### DIFF
--- a/src/Formatters/XmlFormatter.php
+++ b/src/Formatters/XmlFormatter.php
@@ -51,6 +51,9 @@ class XmlFormatter implements FormatterInterface, ValidDataTypesInterface
         if ($structuredData instanceof DomDataInterface) {
             return $structuredData->getDomData();
         }
+        if ($structuredData instanceof \ArrayObject) {
+            return $structuredData->getArrayCopy();
+        }
         if (!is_array($structuredData)) {
             throw new IncompatibleDataException(
                 $this,


### PR DESCRIPTION
Currently when I try to format the output of a command using the `RowsOfFields` data type as XML I'm getting the following error:

> Data provided to Consolidation\OutputFormatters\Formatters\XmlFormatter must be either an instance of DOMDocument or an array. Instead, an instance of Consolidation\OutputFormatters\Transformations\TableTransformation was provided.

`RowsOfFields` is not an array, but since it is an `\ArrayObject` we can derive an array from it.

### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Short overview of what changed.

### Description
Any additional information.
