### PR TITLE
Add ability to select columns from unstructured data 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+### Unreleased - 12 October 2018
+
+- Add UnstructuredListData to replace deprecated ListDataFromKeys
+- Support --field and --fields in commands that return UnstructuredListData
+- Support field remapping, e.g. `--fields=original as remapped`
+
+### 3.2.1 - 25 May 2018
+
+- Rename g1a/composer-test-scenarios
+
 ### 3.2.0 - 20 March 2018
 
 - Add RowsOfFieldsWithMetadata: allows commands to return an object with metadata that shows up in yaml/json (& etc.) formats, but is not shown in table/csv (& etc.).

--- a/LICENSE
+++ b/LICENSE
@@ -10,6 +10,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 DEPENDENCY LICENSES:
 
 Name                       Version  License  
+dflydev/dot-access-data    v1.1.0   MIT      
 psr/log                    1.0.2    MIT      
 symfony/console            v3.2.3   MIT      
 symfony/debug              v3.4.17  MIT      

--- a/LICENSE
+++ b/LICENSE
@@ -12,6 +12,6 @@ DEPENDENCY LICENSES:
 Name                       Version  License  
 psr/log                    1.0.2    MIT      
 symfony/console            v3.2.3   MIT      
-symfony/debug              v3.4.11  MIT      
-symfony/finder             v3.4.11  MIT      
-symfony/polyfill-mbstring  v1.8.0   MIT      
+symfony/debug              v3.4.17  MIT      
+symfony/finder             v3.4.17  MIT      
+symfony/polyfill-mbstring  v1.9.0   MIT      

--- a/README.md
+++ b/README.md
@@ -107,7 +107,9 @@ Zwei
 Ni
 Dos
 ```
-Commands that produce deeply-nested data structures using the `UnstructuredListData` data type may also be manipulated using the `--fields` and `--field` options. It is possible to address items deep in the heirarchy using dot notation.
+Commands that produce deeply-nested data structures using the `UnstructuredData` and `UnstructuredListData` data type may also be manipulated using the `--fields` and `--field` options. It is possible to address items deep in the heirarchy using dot notation.
+
+The `UnstructuredData` type represents a single nested array with no requirements for uniform structure. The `UnstructuredListData` type is similar; it represents a list of `UnstructuredData` types. It is not required for the different elements in the list to have all of the same fields or structure, although it is expected that there will be a certain degree of similarity.
 
 Note that field remapping does not work for commands that use `RowsOfFields` or `PropertyList` return types; this capability is only supported by the `UnstructuredListData` type.
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,70 @@ Commands that produce deeply-nested data structures using the `UnstructuredData`
 
 The `UnstructuredData` type represents a single nested array with no requirements for uniform structure. The `UnstructuredListData` type is similar; it represents a list of `UnstructuredData` types. It is not required for the different elements in the list to have all of the same fields or structure, although it is expected that there will be a certain degree of similarity.
 
-Note that field remapping does not work for commands that use `RowsOfFields` or `PropertyList` return types; this capability is only supported by the `UnstructuredListData` type.
+In the example below, a command returns a list of stores of different kinds. Each store has common top-level elements such as `name`, `products` and `sale-items`. Each store might have different sorts of products with different attributes:
+```
+$ ./app try:nested
+bills-hardware:
+  name: 'Bill''s Hardware'
+  products:
+    tools:
+      electric-drill:
+        price: '79.98'
+      screwdriver:
+        price: '8.99'
+  sale-items:
+    screwdriver: '4.99'
+alberts-supermarket:
+  name: 'Albert''s Supermarket'
+  products:
+    fruits:
+      strawberries:
+        price: '2'
+        units: lbs
+      watermellons:
+        price: '5'
+        units: each
+  sale-items:
+    watermellons: '4.50'
+```
+Just as is the case with tabular output, it is possible to select only a certain set of fields to display with each output item:
+```
+$ ./app try:nested --fields=sale-items
+bills-hardware:
+  sale-items:
+    screwdriver: '4.99'
+alberts-supermarket:
+  sale-items:
+    watermellons: '4.50'
+```
+With unstructured data, it is also possible to remap the name of the field to something else:
+```
+$ ./robo try:nested --fields='sale-items as items'
+bills-hardware:
+  items:
+    screwdriver: '4.99'
+alberts-supermarket:
+  items:
+    watermellons: '4.50'
+```
+The field name `.` is special, though: it indicates that the named element should be omitted, and its value or children should be applied directly to the result row:
+```
+$ ./app try:nested --fields='sale-items as .'
+bills-hardware:
+  screwdriver: '4.99'
+alberts-supermarket:
+  watermellons: '4.50'
+```
+Finally, it is also possible to reach down into nested data structures and pull out information about an element or elements identified using "dot" notation:
+```
+$ ./app try:nested --fields=products.fruits.strawberries
+bills-hardware: {  }
+alberts-supermarket:
+  strawberries:
+    price: '2'
+    units: lbs
+```
+Commands that use `RowsOfFields` or `PropertyList` return type will be automatically converted to `UnstructuredListData` or `UnstructuredData`, respectively, whenever any field remapping is done. This will only work for data types such as `yaml` or `json` that can render unstructured data types. It is not possible to render unstructured data in a table, even if the resulting data happens to be uniform.
 
 ## Filtering Specific Rows
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This is a library intended to be used in some other project.  Require from your 
         "consolidation/output-formatters": "~3"
     },
 ```
-If you require the feature that allows a data table to be automatically reduced to a single element when the `string` format is selected, then you should require version "~2" instead. In most other respects, the 1.x and 2.x versions are compatible. See the [CHANGELOG](CHANGELOG.md) for details.
+If you require the feature that allows a data table to be automatically reduced to a single element when the `string` format is selected, then you should require version ^2 instead. In most other respects, the 1.x and 2.x versions are compatible. See the [CHANGELOG](CHANGELOG.md) for details.
 
 ## Example Formatter
 
@@ -53,14 +53,13 @@ Formatters may also implement different interfaces to alter the behavior of the 
 Most formatters will operate on any array or ArrayObject data. Some formatters require that specific data types be used. The following data types, all of which are subclasses of ArrayObject, are available for use:
 
 - `RowsOfFields`: Each row contains an associative array of field:value pairs. It is also assumed that the fields of each row are the same for every row. This format is ideal for displaying in a table, with labels in the top row.
-- `RowsOfFieldsWithMetadata`: Equivalent to `RowsOfFields`, but allows the data to be nested inside of an element, with other elements being used as metadata, or, alternately, allows the metadata to be nested inside of an element, with all other elements being used as data.
+- `RowsOfFieldsWithMetadata`: Equivalent to `RowsOfFields`, but allows for metadata to be attached to the result. The metadata is not displayed in table format, but is evident if the data is converted to another format (e.g. `yaml` or `json`). The table data may either be nested inside of a specially-designated element, with other elements being used as metadata, or, alternately, the metadata may be nested inside of an element, with all other elements being used as data.
 - `PropertyList`: Each row contains a field:value pair. Each field is unique. This format is ideal for displaying in a table, with labels in the first column and values in the second common.
-- `ListDataFromKeys`: The result may be structured or unstructured data. When formatted with the --format=list formatter, the result will come from the array keys instead of the array values.
+- `UnstructuredListData`: The result is assumed to be a list of items, with the key of each row being used as the row id. The data elements may contain any sort of array data. The elements on each row do not need to be uniform, and the data may be nested to arbitrary depths.
 - `DOMDocument`: The standard PHP DOM document class may be used by functions that need to be able to presicely specify the exact attributes and children when the XML output format is used.
+- `ListDataFromKeys`: This data structure is deprecated. Use `UnstructuredListData` instead.
 
-Commands that return table structured data with fields can be filtered and/or re-ordered by using the --fields option. These structured data types can also be formatted into a more generic type such as yaml or json, even after being filtered. This capabilities are not available if the data is returned in a bare php array.
-
-The formatter manager will do its best to convert from an array to a DOMDocument, or from a DOMDocument to an array. It is important to note that a DOMDocument does not have a 1-to-1 mapping with a PHP array.  DOM elements contain both attributes and elements; a simple string property 'foo' may be represented either as <element foo="value"/> or <element><foo>value</foo></element>. Also, there may be multiple XML elements with the same name, whereas php associative arrays must always have unique keys. When converting from an array to a DOM document, the XML formatter will default to representing the string properties of an array as attributes of the element. Sets of elements with the same name may be used only if they are wrapped in a containing parent element--e.g. <element><foos><foo>one</foo><foo>two</foo></foos></element>. The XMLSchema class may be used to provide control over whether a property is rendered as an attribute or an element; however, in instances where the schema of the XML output is important, it is best for a function to return its result as a DOMDocument rather than an array.
+Commands that need to produce XML output should return a DOMDocument as its return type. The formatter manager will do its best to convert from an array to a DOMDocument, or from a DOMDocument to an array, as needed. It is important to note that a DOMDocument does not have a 1-to-1 mapping with a PHP array.  DOM elements contain both attributes and elements; a simple string property 'foo' may be represented either as <element foo="value"/> or <element><foo>value</foo></element>. Also, there may be multiple XML elements with the same name, whereas php associative arrays must always have unique keys. When converting from an array to a DOM document, the XML formatter will default to representing the string properties of an array as attributes of the element. Sets of elements with the same name may be used only if they are wrapped in a containing parent element--e.g. <element><foos><foo>one</foo><foo>two</foo></foos></element>. The XMLSchema class may be used to provide control over whether a property is rendered as an attribute or an element; however, in instances where the schema of the XML output is important, it is best for a function to return its result as a DOMDocument rather than an array.
 
 A function may also define its own structured data type to return, usually by extending one of the types mentioned above.  If a custom structured data class implements an appropriate interface, then it can provide its own conversion function to one of the other data types:
 
@@ -71,6 +70,50 @@ A function may also define its own structured data type to return, usually by ex
 - `RestructureInterface`: The restructure interface can be implemented by a structured data object to restructure the data in response to options provided by the user. For example, the RowsOfFields and PropertyList data types use this interface to select and reorder the fields that were selected to appear in the output. Custom data types usually will not need to implement this interface, as they can inherit this behavior by extending RowsOfFields or PropertyList.
 
 Additionally, structured data may be simplified to arrays via an array simplification object. To provide an array simplifier, implement `SimplifyToArrayInterface`, and register the simplifier via `FormatterManager::addSimplifier()`.
+
+## Reordering Fields
+
+Commands that return table structured data with fields can be filtered and/or re-ordered by using the --fields option. These structured data types can also be formatted into a more generic type such as yaml or json, even after being filtered. This capabilities are not available if the data is returned in a bare php array. One of `RowsOfFields`, `PropertyList` or `UnstructuredListData` (or similar) must be used.
+
+When the `--fields` option is provided, the user may stipulate the exact fields to list on each row, and what order they should appear in. For example, if a command usually produces output using the `RowsOfFields` data type, as shown below:
+```
+$ ./app try:formatters
+ ------ ------ ------- 
+  I      II     III    
+ ------ ------ ------- 
+  One    Two    Three  
+  Eins   Zwei   Drei   
+  Ichi   Ni     San    
+  Uno    Dos    Tres   
+ ------ ------ ------- 
+```
+Then the third and first fields may be selected as follows:
+```
+ $ ./app try:formatters --fields=III,I
+ ------- ------ 
+  III     I     
+ ------- ------ 
+  Three   One   
+  Drei    Eins  
+  San     Ichi  
+  Tres    Uno   
+ ------- ------ 
+```
+To select a single column and strip away all formatting, use the `--field` option:
+```
+$ ./app try:formatters --field=II
+Two
+Zwei
+Ni
+Dos
+```
+Commands that produce deeply-nested data structures using the `UnstructuredListData` data type may also be manipulated using the `--fields` and `--field` options. It is possible to address items deep in the heirarchy using dot notation.
+
+Note that field remapping does not work for commands that use `RowsOfFields` or `PropertyList` return types; this capability is only supported by the `UnstructuredListData` type.
+
+## Filtering Specific Rows
+
+A command may allow the user to filter specific rows of data using simple boolean logic and/or regular expressions. For details, see the external library [consolidation/filter-via-dot-access-data](https://github.com/consolidation/filter-via-dot-access-data) that provides this capability.
 
 ## Rendering Table Cells
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Most formatters will operate on any array or ArrayObject data. Some formatters r
 - `RowsOfFieldsWithMetadata`: Equivalent to `RowsOfFields`, but allows for metadata to be attached to the result. The metadata is not displayed in table format, but is evident if the data is converted to another format (e.g. `yaml` or `json`). The table data may either be nested inside of a specially-designated element, with other elements being used as metadata, or, alternately, the metadata may be nested inside of an element, with all other elements being used as data.
 - `PropertyList`: Each row contains a field:value pair. Each field is unique. This format is ideal for displaying in a table, with labels in the first column and values in the second common.
 - `UnstructuredListData`: The result is assumed to be a list of items, with the key of each row being used as the row id. The data elements may contain any sort of array data. The elements on each row do not need to be uniform, and the data may be nested to arbitrary depths.
+- `UnstruturedData`: The result is an unstructured array nested to arbitrary levels.
 - `DOMDocument`: The standard PHP DOM document class may be used by functions that need to be able to presicely specify the exact attributes and children when the XML output format is used.
 - `ListDataFromKeys`: This data structure is deprecated. Use `UnstructuredListData` instead.
 

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     },
     "require": {
         "php": ">=5.4.0",
+        "dflydev/dot-access-data": "^1.1.0",
         "symfony/console": "^2.8|^3|^4",
         "symfony/finder": "^2.5|^3|^4"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -118,16 +118,16 @@
         },
         {
             "name": "symfony/debug",
-            "version": "v3.4.11",
+            "version": "v3.4.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "b28fd73fefbac341f673f5efd707d539d6a19f68"
+                "reference": "0a612e9dfbd2ccce03eb174365f31ecdca930ff6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/b28fd73fefbac341f673f5efd707d539d6a19f68",
-                "reference": "b28fd73fefbac341f673f5efd707d539d6a19f68",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/0a612e9dfbd2ccce03eb174365f31ecdca930ff6",
+                "reference": "0a612e9dfbd2ccce03eb174365f31ecdca930ff6",
                 "shasum": ""
             },
             "require": {
@@ -170,20 +170,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2018-05-16T14:03:39+00:00"
+            "time": "2018-10-02T16:33:53+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.4.11",
+            "version": "v3.4.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "472a92f3df8b247b49ae364275fb32943b9656c6"
+                "reference": "54ba444dddc5bd5708a34bd095ea67c6eb54644d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/472a92f3df8b247b49ae364275fb32943b9656c6",
-                "reference": "472a92f3df8b247b49ae364275fb32943b9656c6",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/54ba444dddc5bd5708a34bd095ea67c6eb54644d",
+                "reference": "54ba444dddc5bd5708a34bd095ea67c6eb54644d",
                 "shasum": ""
             },
             "require": {
@@ -219,20 +219,20 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2018-05-16T08:49:21+00:00"
+            "time": "2018-10-03T08:46:40+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.8.0",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "3296adf6a6454a050679cde90f95350ad604b171"
+                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/3296adf6a6454a050679cde90f95350ad604b171",
-                "reference": "3296adf6a6454a050679cde90f95350ad604b171",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d0cd638f4634c16d8df4508e847f14e9e43168b8",
+                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8",
                 "shasum": ""
             },
             "require": {
@@ -244,7 +244,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8-dev"
+                    "dev-master": "1.9-dev"
                 }
             },
             "autoload": {
@@ -278,7 +278,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-04-26T10:06:28+00:00"
+            "time": "2018-08-06T14:22:27+00:00"
         }
     ],
     "packages-dev": [
@@ -338,16 +338,16 @@
         },
         {
             "name": "g1a/composer-test-scenarios",
-            "version": "2.0.1",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/g1a/composer-test-scenarios.git",
-                "reference": "d9a7619f6e1c01498fad19c34539bd5b0d2506ef"
+                "reference": "a166fd15191aceab89f30c097e694b7cf3db4880"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/g1a/composer-test-scenarios/zipball/d9a7619f6e1c01498fad19c34539bd5b0d2506ef",
-                "reference": "d9a7619f6e1c01498fad19c34539bd5b0d2506ef",
+                "url": "https://api.github.com/repos/g1a/composer-test-scenarios/zipball/a166fd15191aceab89f30c097e694b7cf3db4880",
+                "reference": "a166fd15191aceab89f30c097e694b7cf3db4880",
                 "shasum": ""
             },
             "bin": [
@@ -367,7 +367,7 @@
                 }
             ],
             "description": "Useful scripts for testing multiple sets of Composer dependencies.",
-            "time": "2018-05-25T16:45:48+00:00"
+            "time": "2018-08-08T23:37:23+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -743,16 +743,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.7.6",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712"
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
-                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
                 "shasum": ""
             },
             "require": {
@@ -764,12 +764,12 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7.x-dev"
+                    "dev-master": "1.8.x-dev"
                 }
             },
             "autoload": {
@@ -802,7 +802,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-04-18T13:57:24+00:00"
+            "time": "2018-08-05T17:53:17+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1921,16 +1921,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v3.4.11",
+            "version": "v3.4.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "73e055cf2e6467715f187724a0347ea32079967c"
+                "reference": "e5389132dc6320682de3643091121c048ff796b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/73e055cf2e6467715f187724a0347ea32079967c",
-                "reference": "73e055cf2e6467715f187724a0347ea32079967c",
+                "url": "https://api.github.com/repos/symfony/config/zipball/e5389132dc6320682de3643091121c048ff796b3",
+                "reference": "e5389132dc6320682de3643091121c048ff796b3",
                 "shasum": ""
             },
             "require": {
@@ -1981,20 +1981,20 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2018-05-14T16:49:53+00:00"
+            "time": "2018-09-08T13:15:14+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.4.11",
+            "version": "v3.4.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "8e03ca3fa52a0f56b87506f38cf7bd3f9442b3a0"
+                "reference": "d69930fc337d767607267d57c20a7403d0a822a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/8e03ca3fa52a0f56b87506f38cf7bd3f9442b3a0",
-                "reference": "8e03ca3fa52a0f56b87506f38cf7bd3f9442b3a0",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d69930fc337d767607267d57c20a7403d0a822a4",
+                "reference": "d69930fc337d767607267d57c20a7403d0a822a4",
                 "shasum": ""
             },
             "require": {
@@ -2031,29 +2031,32 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2018-05-16T08:49:21+00:00"
+            "time": "2018-10-02T12:28:39+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.8.0",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae"
+                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
-                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e3d826245268269cd66f8326bd8bc066687b4a19",
+                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8-dev"
+                    "dev-master": "1.9-dev"
                 }
             },
             "autoload": {
@@ -2086,20 +2089,20 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2018-04-30T19:57:29+00:00"
+            "time": "2018-08-06T14:22:27+00:00"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v3.4.11",
+            "version": "v3.4.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "eb17cfa072cab26537ac37e9c4ece6c0361369af"
+                "reference": "05e52a39de52ba690aebaed462b2bc8a9649f0a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/eb17cfa072cab26537ac37e9c4ece6c0361369af",
-                "reference": "eb17cfa072cab26537ac37e9c4ece6c0361369af",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/05e52a39de52ba690aebaed462b2bc8a9649f0a4",
+                "reference": "05e52a39de52ba690aebaed462b2bc8a9649f0a4",
                 "shasum": ""
             },
             "require": {
@@ -2135,20 +2138,20 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2018-02-17T14:55:25+00:00"
+            "time": "2018-10-02T12:28:39+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v3.4.11",
+            "version": "v3.4.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "0e6545672d8c9ce70dd472adc2f8b03155a46f73"
+                "reference": "ff8ac19e97e5c7c3979236b584719a1190f84181"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/0e6545672d8c9ce70dd472adc2f8b03155a46f73",
-                "reference": "0e6545672d8c9ce70dd472adc2f8b03155a46f73",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/ff8ac19e97e5c7c3979236b584719a1190f84181",
+                "reference": "ff8ac19e97e5c7c3979236b584719a1190f84181",
                 "shasum": ""
             },
             "require": {
@@ -2204,11 +2207,11 @@
                 "debug",
                 "dump"
             ],
-            "time": "2018-04-26T12:42:15+00:00"
+            "time": "2018-10-02T16:33:53+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.3.17",
+            "version": "v3.3.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,67 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e726e2302b89b56b1cf5c8148a65a648",
+    "content-hash": "5232f66b194c337084b00c3d828a8e62",
     "packages": [
+        {
+            "name": "dflydev/dot-access-data",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dflydev/dflydev-dot-access-data.git",
+                "reference": "3fbd874921ab2c041e899d044585a2ab9795df8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dflydev/dflydev-dot-access-data/zipball/3fbd874921ab2c041e899d044585a2ab9795df8a",
+                "reference": "3fbd874921ab2c041e899d044585a2ab9795df8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Dflydev\\DotAccessData": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dragonfly Development Inc.",
+                    "email": "info@dflydev.com",
+                    "homepage": "http://dflydev.com"
+                },
+                {
+                    "name": "Beau Simensen",
+                    "email": "beau@dflydev.com",
+                    "homepage": "http://beausimensen.com"
+                },
+                {
+                    "name": "Carlos Frutos",
+                    "email": "carlos@kiwing.it",
+                    "homepage": "https://github.com/cfrutos"
+                }
+            ],
+            "description": "Given a deep data structure, access data by dot notation.",
+            "homepage": "https://github.com/dflydev/dflydev-dot-access-data",
+            "keywords": [
+                "access",
+                "data",
+                "dot",
+                "notation"
+            ],
+            "time": "2017-01-20T21:14:22+00:00"
+        },
         {
             "name": "psr/log",
             "version": "1.0.2",

--- a/docs/api.md
+++ b/docs/api.md
@@ -30,6 +30,7 @@
 - [\Consolidation\OutputFormatters\StructuredData\TableDataInterface (interface)](#interface-consolidationoutputformattersstructureddatatabledatainterface)
 - [\Consolidation\OutputFormatters\StructuredData\HelpDocument](#class-consolidationoutputformattersstructureddatahelpdocument)
 - [\Consolidation\OutputFormatters\StructuredData\OriginalDataInterface (interface)](#interface-consolidationoutputformattersstructureddataoriginaldatainterface)
+- [\Consolidation\OutputFormatters\StructuredData\UnstructuredData](#class-consolidationoutputformattersstructureddataunstructureddata)
 - [\Consolidation\OutputFormatters\StructuredData\RowsOfFields](#class-consolidationoutputformattersstructureddatarowsoffields)
 - [\Consolidation\OutputFormatters\StructuredData\RestructureInterface (interface)](#interface-consolidationoutputformattersstructureddatarestructureinterface)
 - [\Consolidation\OutputFormatters\StructuredData\AbstractStructuredList (abstract)](#class-consolidationoutputformattersstructureddataabstractstructuredlist-abstract)
@@ -45,17 +46,20 @@
 - [\Consolidation\OutputFormatters\StructuredData\NumericCellRenderer](#class-consolidationoutputformattersstructureddatanumericcellrenderer)
 - [\Consolidation\OutputFormatters\StructuredData\AssociativeList](#class-consolidationoutputformattersstructureddataassociativelist)
 - [\Consolidation\OutputFormatters\StructuredData\MetadataInterface (interface)](#interface-consolidationoutputformattersstructureddatametadatainterface)
+- [\Consolidation\OutputFormatters\StructuredData\FieldProcessor](#class-consolidationoutputformattersstructureddatafieldprocessor)
 - [\Consolidation\OutputFormatters\StructuredData\Xml\XmlSchemaInterface (interface)](#interface-consolidationoutputformattersstructureddataxmlxmlschemainterface)
 - [\Consolidation\OutputFormatters\StructuredData\Xml\DomDataInterface (interface)](#interface-consolidationoutputformattersstructureddataxmldomdatainterface)
 - [\Consolidation\OutputFormatters\StructuredData\Xml\XmlSchema](#class-consolidationoutputformattersstructureddataxmlxmlschema)
-- [\Consolidation\OutputFormatters\Transformations\SimplifyToStringInterface (interface)](#interface-consolidationoutputformatterstransformationssimplifytostringinterface)
+- [\Consolidation\OutputFormatters\Transformations\UnstructuredDataFieldAccessor](#class-consolidationoutputformatterstransformationsunstructureddatafieldaccessor)
 - [\Consolidation\OutputFormatters\Transformations\PropertyParser](#class-consolidationoutputformatterstransformationspropertyparser)
 - [\Consolidation\OutputFormatters\Transformations\PropertyListTableTransformation](#class-consolidationoutputformatterstransformationspropertylisttabletransformation)
 - [\Consolidation\OutputFormatters\Transformations\TableTransformation](#class-consolidationoutputformatterstransformationstabletransformation)
 - [\Consolidation\OutputFormatters\Transformations\UnstructuredDataTransformation](#class-consolidationoutputformatterstransformationsunstructureddatatransformation)
+- [\Consolidation\OutputFormatters\Transformations\UnstructuredDataListTransformation](#class-consolidationoutputformatterstransformationsunstructureddatalisttransformation)
 - [\Consolidation\OutputFormatters\Transformations\ReorderFields](#class-consolidationoutputformatterstransformationsreorderfields)
 - [\Consolidation\OutputFormatters\Transformations\DomToArraySimplifier](#class-consolidationoutputformatterstransformationsdomtoarraysimplifier)
 - [\Consolidation\OutputFormatters\Transformations\WordWrapper](#class-consolidationoutputformatterstransformationswordwrapper)
+- [\Consolidation\OutputFormatters\Transformations\StringTransformationInterface (interface)](#interface-consolidationoutputformatterstransformationsstringtransformationinterface)
 - [\Consolidation\OutputFormatters\Transformations\OverrideRestructureInterface (interface)](#interface-consolidationoutputformatterstransformationsoverriderestructureinterface)
 - [\Consolidation\OutputFormatters\Transformations\SimplifyToArrayInterface (interface)](#interface-consolidationoutputformatterstransformationssimplifytoarrayinterface)
 - [\Consolidation\OutputFormatters\Transformations\Wrap\CalculateWidths](#class-consolidationoutputformatterstransformationswrapcalculatewidths)
@@ -486,6 +490,21 @@
 
 <hr />
 
+### Class: \Consolidation\OutputFormatters\StructuredData\UnstructuredData
+
+> Represents aribtrary unstructured array data where the data to display in --list format comes from the array keys. Unstructured list data can have variable keys in every rown (unlike RowsOfFields, which expects uniform rows), and the data elements may themselves be deep arrays.
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>__construct(</strong><em>mixed</em> <strong>$data</strong>)</strong> : <em>void</em> |
+| public | <strong>restructure(</strong><em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>void</em> |
+
+*This class extends [\Consolidation\OutputFormatters\StructuredData\AbstractListData](#class-consolidationoutputformattersstructureddataabstractlistdata)*
+
+*This class implements [\Consolidation\OutputFormatters\StructuredData\ListDataInterface](#interface-consolidationoutputformattersstructureddatalistdatainterface), \IteratorAggregate, \Traversable, \ArrayAccess, \Serializable, \Countable, [\Consolidation\OutputFormatters\StructuredData\RestructureInterface](#interface-consolidationoutputformattersstructureddatarestructureinterface)*
+
+<hr />
+
 ### Class: \Consolidation\OutputFormatters\StructuredData\RowsOfFields
 
 > Holds an array where each element of the array is one row, and each row contains an associative array where the keys are the field names, and the values are the field data. It is presumed that every row contains the same keys.
@@ -555,7 +574,6 @@
 |:-----------|:---------|
 | public | <strong>__construct(</strong><em>mixed</em> <strong>$data</strong>)</strong> : <em>void</em> |
 | public | <strong>restructure(</strong><em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>void</em> |
-| protected | <strong>processFieldAliases(</strong><em>mixed</em> <strong>$fields</strong>)</strong> : <em>void</em> |
 
 *This class extends [\Consolidation\OutputFormatters\StructuredData\AbstractListData](#class-consolidationoutputformattersstructureddataabstractlistdata)*
 
@@ -709,6 +727,16 @@
 
 <hr />
 
+### Class: \Consolidation\OutputFormatters\StructuredData\FieldProcessor
+
+> FieldProcessor will do various alterations on field sets.
+
+| Visibility | Function |
+|:-----------|:---------|
+| public static | <strong>processFieldAliases(</strong><em>mixed</em> <strong>$fields</strong>)</strong> : <em>void</em> |
+
+<hr />
+
 ### Interface: \Consolidation\OutputFormatters\StructuredData\Xml\XmlSchemaInterface
 
 > When using arrays, we could represent XML data in a number of different ways. For example, given the following XML data strucutre: <document id="1" name="doc"> <foobars> <foobar id="123"> <name>blah</name> <widgets> <widget> <foo>a</foo> <bar>b</bar> <baz>c</baz> </widget> </widgets> </foobar> </foobars> </document> This could be: [ 'id' => 1, 'name'  => 'doc', 'foobars' => [ [ 'id' => '123', 'name' => 'blah', 'widgets' => [ [ 'foo' => 'a', 'bar' => 'b', 'baz' => 'c', ] ], ], ] ] The challenge is more in going from an array back to the more structured xml format.  Note that any given key => string mapping could represent either an attribute, or a simple XML element containing only a string value. In general, we do *not* want to add extra layers of nesting in the data structure to disambiguate between these kinds of data, as we want the source data to render cleanly into other formats, e.g. yaml, json, et. al., and we do not want to force every data provider to have to consider the optimal xml schema for their data. Our strategy, therefore, is to expect clients that wish to provide a very specific xml representation to return a DOMDocument, and, for other data structures where xml is a secondary concern, then we will use some default heuristics to convert from arrays to xml.
@@ -748,11 +776,12 @@
 
 <hr />
 
-### Interface: \Consolidation\OutputFormatters\Transformations\SimplifyToStringInterface
+### Class: \Consolidation\OutputFormatters\Transformations\UnstructuredDataFieldAccessor
 
 | Visibility | Function |
 |:-----------|:---------|
-| public | <strong>simplifyToString(</strong><em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>void</em><br /><em>simplifyToString is called by the string formatter to convert structured data to a simple string.</em> |
+| public | <strong>__construct(</strong><em>mixed</em> <strong>$data</strong>)</strong> : <em>void</em> |
+| public | <strong>get(</strong><em>mixed</em> <strong>$fields</strong>)</strong> : <em>mixed</em> |
 
 <hr />
 
@@ -775,7 +804,7 @@
 
 *This class extends [\Consolidation\OutputFormatters\Transformations\TableTransformation](#class-consolidationoutputformatterstransformationstabletransformation)*
 
-*This class implements [\Consolidation\OutputFormatters\StructuredData\OriginalDataInterface](#interface-consolidationoutputformattersstructureddataoriginaldatainterface), [\Consolidation\OutputFormatters\Transformations\SimplifyToStringInterface](#interface-consolidationoutputformatterstransformationssimplifytostringinterface), [\Consolidation\OutputFormatters\StructuredData\TableDataInterface](#interface-consolidationoutputformattersstructureddatatabledatainterface), \IteratorAggregate, \Traversable, \ArrayAccess, \Serializable, \Countable*
+*This class implements [\Consolidation\OutputFormatters\StructuredData\OriginalDataInterface](#interface-consolidationoutputformattersstructureddataoriginaldatainterface), [\Consolidation\OutputFormatters\Transformations\StringTransformationInterface](#interface-consolidationoutputformatterstransformationsstringtransformationinterface), [\Consolidation\OutputFormatters\StructuredData\TableDataInterface](#interface-consolidationoutputformattersstructureddatatabledatainterface), \IteratorAggregate, \Traversable, \ArrayAccess, \Serializable, \Countable*
 
 <hr />
 
@@ -802,7 +831,7 @@
 
 *This class extends \ArrayObject*
 
-*This class implements \Countable, \Serializable, \ArrayAccess, \Traversable, \IteratorAggregate, [\Consolidation\OutputFormatters\StructuredData\TableDataInterface](#interface-consolidationoutputformattersstructureddatatabledatainterface), [\Consolidation\OutputFormatters\Transformations\SimplifyToStringInterface](#interface-consolidationoutputformatterstransformationssimplifytostringinterface), [\Consolidation\OutputFormatters\StructuredData\OriginalDataInterface](#interface-consolidationoutputformattersstructureddataoriginaldatainterface)*
+*This class implements \Countable, \Serializable, \ArrayAccess, \Traversable, \IteratorAggregate, [\Consolidation\OutputFormatters\StructuredData\TableDataInterface](#interface-consolidationoutputformattersstructureddatatabledatainterface), [\Consolidation\OutputFormatters\Transformations\StringTransformationInterface](#interface-consolidationoutputformatterstransformationsstringtransformationinterface), [\Consolidation\OutputFormatters\StructuredData\OriginalDataInterface](#interface-consolidationoutputformattersstructureddataoriginaldatainterface)*
 
 <hr />
 
@@ -811,15 +840,28 @@
 | Visibility | Function |
 |:-----------|:---------|
 | public | <strong>__construct(</strong><em>mixed</em> <strong>$data</strong>, <em>mixed</em> <strong>$fields</strong>)</strong> : <em>void</em> |
+| public static | <strong>simplifyRow(</strong><em>mixed</em> <strong>$row</strong>)</strong> : <em>void</em> |
 | public | <strong>simplifyToString(</strong><em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>void</em> |
-| protected | <strong>isSimpleArray(</strong><em>mixed</em> <strong>$row</strong>)</strong> : <em>bool</em> |
-| protected | <strong>simplifyRow(</strong><em>mixed</em> <strong>$row</strong>)</strong> : <em>void</em> |
-| protected static | <strong>transformRow(</strong><em>mixed</em> <strong>$row</strong>, <em>mixed</em> <strong>$fields</strong>)</strong> : <em>void</em> |
+| public static | <strong>transformRow(</strong><em>mixed</em> <strong>$row</strong>, <em>mixed</em> <strong>$fields</strong>)</strong> : <em>void</em> |
+| protected static | <strong>isSimpleArray(</strong><em>mixed</em> <strong>$row</strong>)</strong> : <em>bool</em> |
+
+*This class extends \ArrayObject*
+
+*This class implements \Countable, \Serializable, \ArrayAccess, \Traversable, \IteratorAggregate, [\Consolidation\OutputFormatters\Transformations\StringTransformationInterface](#interface-consolidationoutputformatterstransformationsstringtransformationinterface)*
+
+<hr />
+
+### Class: \Consolidation\OutputFormatters\Transformations\UnstructuredDataListTransformation
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>__construct(</strong><em>mixed</em> <strong>$data</strong>, <em>mixed</em> <strong>$fields</strong>)</strong> : <em>void</em> |
+| public | <strong>simplifyToString(</strong><em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>void</em> |
 | protected static | <strong>transformRows(</strong><em>mixed</em> <strong>$data</strong>, <em>mixed</em> <strong>$fields</strong>)</strong> : <em>void</em> |
 
 *This class extends \ArrayObject*
 
-*This class implements \Countable, \Serializable, \ArrayAccess, \Traversable, \IteratorAggregate, [\Consolidation\OutputFormatters\Transformations\SimplifyToStringInterface](#interface-consolidationoutputformatterstransformationssimplifytostringinterface)*
+*This class implements \Countable, \Serializable, \ArrayAccess, \Traversable, \IteratorAggregate, [\Consolidation\OutputFormatters\Transformations\StringTransformationInterface](#interface-consolidationoutputformatterstransformationsstringtransformationinterface)*
 
 <hr />
 
@@ -872,6 +914,14 @@
 | public | <strong>wrap(</strong><em>array</em> <strong>$rows</strong>, <em>array</em> <strong>$widths=array()</strong>)</strong> : <em>array</em><br /><em>Wrap the cells in each part of the provided data table</em> |
 | protected | <strong>calculateWidths(</strong><em>mixed</em> <strong>$rows</strong>, <em>array</em> <strong>$widths=array()</strong>)</strong> : <em>void</em><br /><em>Determine what widths we'll use for wrapping.</em> |
 | protected | <strong>wrapCell(</strong><em>mixed</em> <strong>$cell</strong>, <em>string</em> <strong>$cellWidth</strong>)</strong> : <em>mixed</em><br /><em>Wrap one cell.  Guard against modifying non-strings and then call through to wordwrap().</em> |
+
+<hr />
+
+### Interface: \Consolidation\OutputFormatters\Transformations\StringTransformationInterface
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>simplifyToString(</strong><em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>void</em><br /><em>simplifyToString is called by the string formatter to convert structured data to a simple string.</em> |
 
 <hr />
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -37,6 +37,7 @@
 - [\Consolidation\OutputFormatters\StructuredData\ListDataFromKeys](#class-consolidationoutputformattersstructureddatalistdatafromkeys)
 - [\Consolidation\OutputFormatters\StructuredData\UnstructuredListData](#class-consolidationoutputformattersstructureddataunstructuredlistdata)
 - [\Consolidation\OutputFormatters\StructuredData\PropertyList](#class-consolidationoutputformattersstructureddatapropertylist)
+- [\Consolidation\OutputFormatters\StructuredData\ConversionInterface (interface)](#interface-consolidationoutputformattersstructureddataconversioninterface)
 - [\Consolidation\OutputFormatters\StructuredData\MetadataHolderInterface (interface)](#interface-consolidationoutputformattersstructureddatametadataholderinterface)
 - [\Consolidation\OutputFormatters\StructuredData\RenderCellInterface (interface)](#interface-consolidationoutputformattersstructureddatarendercellinterface)
 - [\Consolidation\OutputFormatters\StructuredData\CallableRenderer](#class-consolidationoutputformattersstructureddatacallablerenderer)
@@ -81,6 +82,7 @@
 | public | <strong>addFormatter(</strong><em>string</em> <strong>$key</strong>, <em>string/[\Consolidation\OutputFormatters\Formatters\FormatterInterface](#interface-consolidationoutputformattersformattersformatterinterface)</em> <strong>$formatter</strong>)</strong> : <em>[\Consolidation\OutputFormatters\FormatterManager](#class-consolidationoutputformattersformattermanager)</em><br /><em>Add a formatter</em> |
 | public | <strong>addSimplifier(</strong><em>[\Consolidation\OutputFormatters\Transformations\SimplifyToArrayInterface](#interface-consolidationoutputformatterstransformationssimplifytoarrayinterface)</em> <strong>$simplifier</strong>)</strong> : <em>[\Consolidation\OutputFormatters\FormatterManager](#class-consolidationoutputformattersformattermanager)</em><br /><em>Add a simplifier</em> |
 | public | <strong>automaticOptions(</strong><em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>, <em>mixed</em> <strong>$dataType</strong>)</strong> : <em>\Symfony\Component\Console\Input\InputOption[]</em><br /><em>Return a set of InputOption based on the annotations of a command.</em> |
+| public | <strong>convertData(</strong><em>mixed</em> <strong>$structuredOutput</strong>, <em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>void</em><br /><em>Convert from one format to another if necessary prior to restructuring.</em> |
 | public | <strong>getFormatter(</strong><em>string</em> <strong>$format</strong>)</strong> : <em>[\Consolidation\OutputFormatters\Formatters\FormatterInterface](#interface-consolidationoutputformattersformattersformatterinterface)</em><br /><em>Fetch the requested formatter.</em> |
 | public | <strong>hasFormatter(</strong><em>mixed</em> <strong>$format</strong>)</strong> : <em>bool</em><br /><em>Test to see if the stipulated format exists</em> |
 | public | <strong>isValidDataType(</strong><em>[\Consolidation\OutputFormatters\Formatters\FormatterInterface](#interface-consolidationoutputformattersformattersformatterinterface)</em> <strong>$formatter</strong>, <em>[\ReflectionClass](http://php.net/manual/en/class.reflectionclass.php)</em> <strong>$dataType</strong>)</strong> : <em>bool</em> |
@@ -511,13 +513,14 @@
 
 | Visibility | Function |
 |:-----------|:---------|
+| public | <strong>convert(</strong><em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>void</em><br /><em>Allow structured data to be converted -- i.e. from RowsOfFields to UnstructuredListData.</em> |
 | public | <strong>getListData(</strong><em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>mixed</em> |
 | public | <strong>restructure(</strong><em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>\Consolidation\OutputFormatters\StructuredData\Consolidation\OutputFormatters\Transformations\TableTransformation</em><br /><em>Restructure this data for output by converting it into a table transformation object.</em> |
 | protected | <strong>defaultOptions()</strong> : <em>void</em> |
 
 *This class extends [\Consolidation\OutputFormatters\StructuredData\AbstractStructuredList](#class-consolidationoutputformattersstructureddataabstractstructuredlist-abstract)*
 
-*This class implements [\Consolidation\OutputFormatters\StructuredData\RenderCellInterface](#interface-consolidationoutputformattersstructureddatarendercellinterface), [\Consolidation\OutputFormatters\Formatters\FormatterAwareInterface](#interface-consolidationoutputformattersformattersformatterawareinterface), [\Consolidation\OutputFormatters\StructuredData\RenderCellCollectionInterface](#interface-consolidationoutputformattersstructureddatarendercellcollectioninterface), [\Consolidation\OutputFormatters\StructuredData\RestructureInterface](#interface-consolidationoutputformattersstructureddatarestructureinterface), \Countable, \Serializable, \ArrayAccess, \Traversable, \IteratorAggregate, [\Consolidation\OutputFormatters\StructuredData\ListDataInterface](#interface-consolidationoutputformattersstructureddatalistdatainterface)*
+*This class implements [\Consolidation\OutputFormatters\StructuredData\RenderCellInterface](#interface-consolidationoutputformattersstructureddatarendercellinterface), [\Consolidation\OutputFormatters\Formatters\FormatterAwareInterface](#interface-consolidationoutputformattersformattersformatterawareinterface), [\Consolidation\OutputFormatters\StructuredData\RenderCellCollectionInterface](#interface-consolidationoutputformattersstructureddatarendercellcollectioninterface), [\Consolidation\OutputFormatters\StructuredData\RestructureInterface](#interface-consolidationoutputformattersstructureddatarestructureinterface), \Countable, \Serializable, \ArrayAccess, \Traversable, \IteratorAggregate, [\Consolidation\OutputFormatters\StructuredData\ListDataInterface](#interface-consolidationoutputformattersstructureddatalistdatainterface), [\Consolidation\OutputFormatters\StructuredData\ConversionInterface](#interface-consolidationoutputformattersstructureddataconversioninterface)*
 
 <hr />
 
@@ -587,6 +590,7 @@
 
 | Visibility | Function |
 |:-----------|:---------|
+| public | <strong>convert(</strong><em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>void</em><br /><em>Allow structured data to be converted -- i.e. from RowsOfFields to UnstructuredListData.</em> |
 | public | <strong>getListData(</strong><em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>mixed</em> |
 | public | <strong>restructure(</strong><em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>\Consolidation\OutputFormatters\StructuredData\Consolidation\OutputFormatters\Transformations\TableTransformation</em><br /><em>Restructure this data for output by converting it into a table transformation object.</em> |
 | protected | <strong>defaultOptions()</strong> : <em>void</em> |
@@ -594,7 +598,15 @@
 
 *This class extends [\Consolidation\OutputFormatters\StructuredData\AbstractStructuredList](#class-consolidationoutputformattersstructureddataabstractstructuredlist-abstract)*
 
-*This class implements [\Consolidation\OutputFormatters\StructuredData\RenderCellInterface](#interface-consolidationoutputformattersstructureddatarendercellinterface), [\Consolidation\OutputFormatters\Formatters\FormatterAwareInterface](#interface-consolidationoutputformattersformattersformatterawareinterface), [\Consolidation\OutputFormatters\StructuredData\RenderCellCollectionInterface](#interface-consolidationoutputformattersstructureddatarendercellcollectioninterface), [\Consolidation\OutputFormatters\StructuredData\RestructureInterface](#interface-consolidationoutputformattersstructureddatarestructureinterface), \Countable, \Serializable, \ArrayAccess, \Traversable, \IteratorAggregate, [\Consolidation\OutputFormatters\StructuredData\ListDataInterface](#interface-consolidationoutputformattersstructureddatalistdatainterface)*
+*This class implements [\Consolidation\OutputFormatters\StructuredData\RenderCellInterface](#interface-consolidationoutputformattersstructureddatarendercellinterface), [\Consolidation\OutputFormatters\Formatters\FormatterAwareInterface](#interface-consolidationoutputformattersformattersformatterawareinterface), [\Consolidation\OutputFormatters\StructuredData\RenderCellCollectionInterface](#interface-consolidationoutputformattersstructureddatarendercellcollectioninterface), [\Consolidation\OutputFormatters\StructuredData\RestructureInterface](#interface-consolidationoutputformattersstructureddatarestructureinterface), \Countable, \Serializable, \ArrayAccess, \Traversable, \IteratorAggregate, [\Consolidation\OutputFormatters\StructuredData\ListDataInterface](#interface-consolidationoutputformattersstructureddatalistdatainterface), [\Consolidation\OutputFormatters\StructuredData\ConversionInterface](#interface-consolidationoutputformattersstructureddataconversioninterface)*
+
+<hr />
+
+### Interface: \Consolidation\OutputFormatters\StructuredData\ConversionInterface
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>convert(</strong><em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>void</em><br /><em>Allow structured data to be converted -- i.e. from RowsOfFields to UnstructuredListData.</em> |
 
 <hr />
 
@@ -666,6 +678,7 @@
 | Visibility | Function |
 |:-----------|:---------|
 | public | <strong>__constructor(</strong><em>mixed</em> <strong>$data</strong>)</strong> : <em>void</em> |
+| public | <strong>convert(</strong><em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>void</em><br /><em>Allow structured data to be converted -- i.e. from RowsOfFields to UnstructuredListData.</em> |
 | public | <strong>extractData(</strong><em>mixed</em> <strong>$data</strong>)</strong> : <em>void</em> |
 | public | <strong>extractMetadata(</strong><em>mixed</em> <strong>$data</strong>)</strong> : <em>void</em> |
 | public | <strong>getDataKey()</strong> : <em>mixed</em> |
@@ -678,7 +691,7 @@
 
 *This class extends [\Consolidation\OutputFormatters\StructuredData\RowsOfFields](#class-consolidationoutputformattersstructureddatarowsoffields)*
 
-*This class implements [\Consolidation\OutputFormatters\StructuredData\ListDataInterface](#interface-consolidationoutputformattersstructureddatalistdatainterface), \IteratorAggregate, \Traversable, \ArrayAccess, \Serializable, \Countable, [\Consolidation\OutputFormatters\StructuredData\RestructureInterface](#interface-consolidationoutputformattersstructureddatarestructureinterface), [\Consolidation\OutputFormatters\StructuredData\RenderCellCollectionInterface](#interface-consolidationoutputformattersstructureddatarendercellcollectioninterface), [\Consolidation\OutputFormatters\Formatters\FormatterAwareInterface](#interface-consolidationoutputformattersformattersformatterawareinterface), [\Consolidation\OutputFormatters\StructuredData\RenderCellInterface](#interface-consolidationoutputformattersstructureddatarendercellinterface), [\Consolidation\OutputFormatters\StructuredData\MetadataInterface](#interface-consolidationoutputformattersstructureddatametadatainterface), [\Consolidation\OutputFormatters\StructuredData\MetadataHolderInterface](#interface-consolidationoutputformattersstructureddatametadataholderinterface)*
+*This class implements [\Consolidation\OutputFormatters\StructuredData\ConversionInterface](#interface-consolidationoutputformattersstructureddataconversioninterface), [\Consolidation\OutputFormatters\StructuredData\ListDataInterface](#interface-consolidationoutputformattersstructureddatalistdatainterface), \IteratorAggregate, \Traversable, \ArrayAccess, \Serializable, \Countable, [\Consolidation\OutputFormatters\StructuredData\RestructureInterface](#interface-consolidationoutputformattersstructureddatarestructureinterface), [\Consolidation\OutputFormatters\StructuredData\RenderCellCollectionInterface](#interface-consolidationoutputformattersstructureddatarendercellcollectioninterface), [\Consolidation\OutputFormatters\Formatters\FormatterAwareInterface](#interface-consolidationoutputformattersformattersformatterawareinterface), [\Consolidation\OutputFormatters\StructuredData\RenderCellInterface](#interface-consolidationoutputformattersstructureddatarendercellinterface), [\Consolidation\OutputFormatters\StructuredData\MetadataInterface](#interface-consolidationoutputformattersstructureddatametadatainterface), [\Consolidation\OutputFormatters\StructuredData\MetadataHolderInterface](#interface-consolidationoutputformattersstructureddatametadataholderinterface)*
 
 <hr />
 
@@ -712,10 +725,11 @@
 
 | Visibility | Function |
 |:-----------|:---------|
+| public | <strong>convert(</strong><em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>void</em><br /><em>Allow structured data to be converted -- i.e. from RowsOfFields to UnstructuredListData.</em> |
 
 *This class extends [\Consolidation\OutputFormatters\StructuredData\PropertyList](#class-consolidationoutputformattersstructureddatapropertylist)*
 
-*This class implements [\Consolidation\OutputFormatters\StructuredData\ListDataInterface](#interface-consolidationoutputformattersstructureddatalistdatainterface), \IteratorAggregate, \Traversable, \ArrayAccess, \Serializable, \Countable, [\Consolidation\OutputFormatters\StructuredData\RestructureInterface](#interface-consolidationoutputformattersstructureddatarestructureinterface), [\Consolidation\OutputFormatters\StructuredData\RenderCellCollectionInterface](#interface-consolidationoutputformattersstructureddatarendercellcollectioninterface), [\Consolidation\OutputFormatters\Formatters\FormatterAwareInterface](#interface-consolidationoutputformattersformattersformatterawareinterface), [\Consolidation\OutputFormatters\StructuredData\RenderCellInterface](#interface-consolidationoutputformattersstructureddatarendercellinterface)*
+*This class implements [\Consolidation\OutputFormatters\StructuredData\ConversionInterface](#interface-consolidationoutputformattersstructureddataconversioninterface), [\Consolidation\OutputFormatters\StructuredData\ListDataInterface](#interface-consolidationoutputformattersstructureddatalistdatainterface), \IteratorAggregate, \Traversable, \ArrayAccess, \Serializable, \Countable, [\Consolidation\OutputFormatters\StructuredData\RestructureInterface](#interface-consolidationoutputformattersstructureddatarestructureinterface), [\Consolidation\OutputFormatters\StructuredData\RenderCellCollectionInterface](#interface-consolidationoutputformattersstructureddatarendercellcollectioninterface), [\Consolidation\OutputFormatters\Formatters\FormatterAwareInterface](#interface-consolidationoutputformattersformattersformatterawareinterface), [\Consolidation\OutputFormatters\StructuredData\RenderCellInterface](#interface-consolidationoutputformattersstructureddatarendercellinterface)*
 
 <hr />
 
@@ -733,6 +747,7 @@
 
 | Visibility | Function |
 |:-----------|:---------|
+| public static | <strong>hasUnstructuredFieldAccess(</strong><em>mixed</em> <strong>$options</strong>)</strong> : <em>bool</em> |
 | public static | <strong>processFieldAliases(</strong><em>mixed</em> <strong>$fields</strong>)</strong> : <em>void</em> |
 
 <hr />

--- a/docs/api.md
+++ b/docs/api.md
@@ -747,7 +747,7 @@
 
 | Visibility | Function |
 |:-----------|:---------|
-| public static | <strong>hasUnstructuredFieldAccess(</strong><em>mixed</em> <strong>$options</strong>)</strong> : <em>bool</em> |
+| public static | <strong>hasUnstructuredFieldAccess(</strong><em>\Consolidation\OutputFormatters\StructuredData\type</em> <strong>$fields</strong>)</strong> : <em>\Consolidation\OutputFormatters\StructuredData\type</em><br /><em>Determine whether the data structure has unstructured field access, e.g. `a.b.c` or `foo as bar`.</em> |
 | public static | <strong>processFieldAliases(</strong><em>mixed</em> <strong>$fields</strong>)</strong> : <em>void</em> |
 
 <hr />

--- a/docs/api.md
+++ b/docs/api.md
@@ -34,10 +34,12 @@
 - [\Consolidation\OutputFormatters\StructuredData\RestructureInterface (interface)](#interface-consolidationoutputformattersstructureddatarestructureinterface)
 - [\Consolidation\OutputFormatters\StructuredData\AbstractStructuredList (abstract)](#class-consolidationoutputformattersstructureddataabstractstructuredlist-abstract)
 - [\Consolidation\OutputFormatters\StructuredData\ListDataFromKeys](#class-consolidationoutputformattersstructureddatalistdatafromkeys)
+- [\Consolidation\OutputFormatters\StructuredData\UnstructuredListData](#class-consolidationoutputformattersstructureddataunstructuredlistdata)
 - [\Consolidation\OutputFormatters\StructuredData\PropertyList](#class-consolidationoutputformattersstructureddatapropertylist)
 - [\Consolidation\OutputFormatters\StructuredData\MetadataHolderInterface (interface)](#interface-consolidationoutputformattersstructureddatametadataholderinterface)
 - [\Consolidation\OutputFormatters\StructuredData\RenderCellInterface (interface)](#interface-consolidationoutputformattersstructureddatarendercellinterface)
 - [\Consolidation\OutputFormatters\StructuredData\CallableRenderer](#class-consolidationoutputformattersstructureddatacallablerenderer)
+- [\Consolidation\OutputFormatters\StructuredData\AbstractListData](#class-consolidationoutputformattersstructureddataabstractlistdata)
 - [\Consolidation\OutputFormatters\StructuredData\RenderCellCollectionInterface (interface)](#interface-consolidationoutputformattersstructureddatarendercellcollectioninterface)
 - [\Consolidation\OutputFormatters\StructuredData\RowsOfFieldsWithMetadata](#class-consolidationoutputformattersstructureddatarowsoffieldswithmetadata)
 - [\Consolidation\OutputFormatters\StructuredData\NumericCellRenderer](#class-consolidationoutputformattersstructureddatanumericcellrenderer)
@@ -46,9 +48,11 @@
 - [\Consolidation\OutputFormatters\StructuredData\Xml\XmlSchemaInterface (interface)](#interface-consolidationoutputformattersstructureddataxmlxmlschemainterface)
 - [\Consolidation\OutputFormatters\StructuredData\Xml\DomDataInterface (interface)](#interface-consolidationoutputformattersstructureddataxmldomdatainterface)
 - [\Consolidation\OutputFormatters\StructuredData\Xml\XmlSchema](#class-consolidationoutputformattersstructureddataxmlxmlschema)
+- [\Consolidation\OutputFormatters\Transformations\SimplifyToStringInterface (interface)](#interface-consolidationoutputformatterstransformationssimplifytostringinterface)
 - [\Consolidation\OutputFormatters\Transformations\PropertyParser](#class-consolidationoutputformatterstransformationspropertyparser)
 - [\Consolidation\OutputFormatters\Transformations\PropertyListTableTransformation](#class-consolidationoutputformatterstransformationspropertylisttabletransformation)
 - [\Consolidation\OutputFormatters\Transformations\TableTransformation](#class-consolidationoutputformatterstransformationstabletransformation)
+- [\Consolidation\OutputFormatters\Transformations\UnstructuredDataTransformation](#class-consolidationoutputformatterstransformationsunstructureddatatransformation)
 - [\Consolidation\OutputFormatters\Transformations\ReorderFields](#class-consolidationoutputformatterstransformationsreorderfields)
 - [\Consolidation\OutputFormatters\Transformations\DomToArraySimplifier](#class-consolidationoutputformatterstransformationsdomtoarraysimplifier)
 - [\Consolidation\OutputFormatters\Transformations\WordWrapper](#class-consolidationoutputformatterstransformationswordwrapper)
@@ -287,7 +291,7 @@
 | public | <strong>overrideOptions(</strong><em>mixed</em> <strong>$structuredOutput</strong>, <em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em><br /><em>Allow the formatter to mess with the configuration options before any transformations et. al. get underway.</em> |
 | public | <strong>validate(</strong><em>mixed</em> <strong>$structuredData</strong>)</strong> : <em>void</em><br /><em>Always validate any data, though. This format will never cause an error if it is selected for an incompatible data type; at worse, it simply does not print any data.</em> |
 | public | <strong>write(</strong><em>\Symfony\Component\Console\Output\OutputInterface</em> <strong>$output</strong>, <em>mixed</em> <strong>$data</strong>, <em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>void</em><br /><em>Given structured data, apply appropriate formatting, and return a printable string.</em> |
-| protected | <strong>reduceToSigleFieldAndWrite(</strong><em>\Symfony\Component\Console\Output\OutputInterface</em> <strong>$output</strong>, <em>mixed</em> <strong>$data</strong>, <em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>void</em><br /><em>If the data provided to a 'string' formatter is a table, then try to emit it as a TSV value.</em> |
+| protected | <strong>reduceToSigleFieldAndWrite(</strong><em>\Symfony\Component\Console\Output\OutputInterface</em> <strong>$output</strong>, <em>mixed</em> <strong>$data</strong>, <em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>void</em><br /><em>If the data provided to a 'string' formatter is a table, then try to emit it in a simplified form (by default, TSV).</em> |
 
 *This class implements [\Consolidation\OutputFormatters\Formatters\FormatterInterface](#interface-consolidationoutputformattersformattersformatterinterface), [\Consolidation\OutputFormatters\Validate\ValidationInterface](#interface-consolidationoutputformattersvalidatevalidationinterface), [\Consolidation\OutputFormatters\Options\OverrideOptionsInterface](#interface-consolidationoutputformattersoptionsoverrideoptionsinterface)*
 
@@ -521,29 +525,41 @@
 | public | <strong>abstract restructure(</strong><em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>void</em> |
 | public | <strong>setFormatter(</strong><em>[\Consolidation\OutputFormatters\Formatters\FormatterInterface](#interface-consolidationoutputformattersformattersformatterinterface)</em> <strong>$formatter</strong>)</strong> : <em>void</em> |
 | protected | <strong>createTableTransformation(</strong><em>mixed</em> <strong>$data</strong>, <em>mixed</em> <strong>$options</strong>)</strong> : <em>mixed</em> |
-| protected | <strong>defaultOptions()</strong> : <em>array</em><br /><em>A structured list may provide its own set of default options. These will be used in place of the command's default options (from the annotations) in instances where the user does not provide the options explicitly (on the commandline) or implicitly (via a configuration file).</em> |
-| protected | <strong>getFields(</strong><em>mixed</em> <strong>$options</strong>, <em>mixed</em> <strong>$defaults</strong>)</strong> : <em>mixed</em> |
-| protected | <strong>getReorderedFieldLabels(</strong><em>mixed</em> <strong>$data</strong>, <em>mixed</em> <strong>$options</strong>, <em>mixed</em> <strong>$defaults</strong>)</strong> : <em>mixed</em> |
+| protected | <strong>defaultOptions()</strong> : <em>void</em> |
 | protected | <strong>instantiateTableTransformation(</strong><em>mixed</em> <strong>$data</strong>, <em>mixed</em> <strong>$fieldLabels</strong>, <em>mixed</em> <strong>$rowLabels</strong>)</strong> : <em>void</em> |
 
-*This class extends [\Consolidation\OutputFormatters\StructuredData\ListDataFromKeys](#class-consolidationoutputformattersstructureddatalistdatafromkeys)*
+*This class extends [\Consolidation\OutputFormatters\StructuredData\AbstractListData](#class-consolidationoutputformattersstructureddataabstractlistdata)*
 
 *This class implements [\Consolidation\OutputFormatters\StructuredData\ListDataInterface](#interface-consolidationoutputformattersstructureddatalistdatainterface), \IteratorAggregate, \Traversable, \ArrayAccess, \Serializable, \Countable, [\Consolidation\OutputFormatters\StructuredData\RestructureInterface](#interface-consolidationoutputformattersstructureddatarestructureinterface), [\Consolidation\OutputFormatters\StructuredData\RenderCellCollectionInterface](#interface-consolidationoutputformattersstructureddatarendercellcollectioninterface), [\Consolidation\OutputFormatters\Formatters\FormatterAwareInterface](#interface-consolidationoutputformattersformattersformatterawareinterface), [\Consolidation\OutputFormatters\StructuredData\RenderCellInterface](#interface-consolidationoutputformattersstructureddatarendercellinterface)*
 
 <hr />
 
-### Class: \Consolidation\OutputFormatters\StructuredData\ListDataFromKeys
+### <strike>Class: \Consolidation\OutputFormatters\StructuredData\ListDataFromKeys</strike>
 
-> Represents aribtrary array data (structured or unstructured) where the data to display in --list format comes from the array keys.
+> **DEPRECATED** Use UnstructuredListData
+
+| Visibility | Function |
+|:-----------|:---------|
+
+*This class extends [\Consolidation\OutputFormatters\StructuredData\AbstractListData](#class-consolidationoutputformattersstructureddataabstractlistdata)*
+
+*This class implements [\Consolidation\OutputFormatters\StructuredData\ListDataInterface](#interface-consolidationoutputformattersstructureddatalistdatainterface), \IteratorAggregate, \Traversable, \ArrayAccess, \Serializable, \Countable*
+
+<hr />
+
+### Class: \Consolidation\OutputFormatters\StructuredData\UnstructuredListData
+
+> Represents aribtrary unstructured array data where the data to display in --list format comes from the array keys. Unstructured list data can have variable keys in every rown (unlike RowsOfFields, which expects uniform rows), and the data elements may themselves be deep arrays.
 
 | Visibility | Function |
 |:-----------|:---------|
 | public | <strong>__construct(</strong><em>mixed</em> <strong>$data</strong>)</strong> : <em>void</em> |
-| public | <strong>getListData(</strong><em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>mixed</em> |
+| public | <strong>restructure(</strong><em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>void</em> |
+| protected | <strong>processFieldAliases(</strong><em>mixed</em> <strong>$fields</strong>)</strong> : <em>void</em> |
 
-*This class extends \ArrayObject*
+*This class extends [\Consolidation\OutputFormatters\StructuredData\AbstractListData](#class-consolidationoutputformattersstructureddataabstractlistdata)*
 
-*This class implements \Countable, \Serializable, \ArrayAccess, \Traversable, \IteratorAggregate, [\Consolidation\OutputFormatters\StructuredData\ListDataInterface](#interface-consolidationoutputformattersstructureddatalistdatainterface)*
+*This class implements [\Consolidation\OutputFormatters\StructuredData\ListDataInterface](#interface-consolidationoutputformattersstructureddatalistdatainterface), \IteratorAggregate, \Traversable, \ArrayAccess, \Serializable, \Countable, [\Consolidation\OutputFormatters\StructuredData\RestructureInterface](#interface-consolidationoutputformattersstructureddatarestructureinterface)*
 
 <hr />
 
@@ -594,6 +610,24 @@
 | public | <strong>renderCell(</strong><em>mixed</em> <strong>$key</strong>, <em>mixed</em> <strong>$cellData</strong>, <em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>, <em>mixed</em> <strong>$rowData</strong>)</strong> : <em>void</em> |
 
 *This class implements [\Consolidation\OutputFormatters\StructuredData\RenderCellInterface](#interface-consolidationoutputformattersstructureddatarendercellinterface)*
+
+<hr />
+
+### Class: \Consolidation\OutputFormatters\StructuredData\AbstractListData
+
+> Base class for all list data types.
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>__construct(</strong><em>mixed</em> <strong>$data</strong>)</strong> : <em>void</em> |
+| public | <strong>getListData(</strong><em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>mixed</em> |
+| protected | <strong>defaultOptions()</strong> : <em>array</em><br /><em>A structured list may provide its own set of default options. These will be used in place of the command's default options (from the annotations) in instances where the user does not provide the options explicitly (on the commandline) or implicitly (via a configuration file).</em> |
+| protected | <strong>getFields(</strong><em>mixed</em> <strong>$options</strong>, <em>mixed</em> <strong>$defaults</strong>)</strong> : <em>mixed</em> |
+| protected | <strong>getReorderedFieldLabels(</strong><em>mixed</em> <strong>$data</strong>, <em>mixed</em> <strong>$options</strong>, <em>mixed</em> <strong>$defaults</strong>)</strong> : <em>mixed</em> |
+
+*This class extends \ArrayObject*
+
+*This class implements \Countable, \Serializable, \ArrayAccess, \Traversable, \IteratorAggregate, [\Consolidation\OutputFormatters\StructuredData\ListDataInterface](#interface-consolidationoutputformattersstructureddatalistdatainterface)*
 
 <hr />
 
@@ -714,6 +748,14 @@
 
 <hr />
 
+### Interface: \Consolidation\OutputFormatters\Transformations\SimplifyToStringInterface
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>simplifyToString(</strong><em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>void</em><br /><em>simplifyToString is called by the string formatter to convert structured data to a simple string.</em> |
+
+<hr />
+
 ### Class: \Consolidation\OutputFormatters\Transformations\PropertyParser
 
 > Transform a string of properties into a PHP associative array. Input: one: red two: white three: blue Output: [ 'one' => 'red', 'two' => 'white', 'three' => 'blue', ]
@@ -729,10 +771,11 @@
 | Visibility | Function |
 |:-----------|:---------|
 | public | <strong>getOriginalData()</strong> : <em>mixed</em> |
+| public | <strong>simplifyToString(</strong><em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>void</em><br /><em>simplifyToString is called by the string formatter to convert structured data to a simple string.</em> |
 
 *This class extends [\Consolidation\OutputFormatters\Transformations\TableTransformation](#class-consolidationoutputformatterstransformationstabletransformation)*
 
-*This class implements [\Consolidation\OutputFormatters\StructuredData\OriginalDataInterface](#interface-consolidationoutputformattersstructureddataoriginaldatainterface), [\Consolidation\OutputFormatters\StructuredData\TableDataInterface](#interface-consolidationoutputformattersstructureddatatabledatainterface), \IteratorAggregate, \Traversable, \ArrayAccess, \Serializable, \Countable*
+*This class implements [\Consolidation\OutputFormatters\StructuredData\OriginalDataInterface](#interface-consolidationoutputformattersstructureddataoriginaldatainterface), [\Consolidation\OutputFormatters\Transformations\SimplifyToStringInterface](#interface-consolidationoutputformatterstransformationssimplifytostringinterface), [\Consolidation\OutputFormatters\StructuredData\TableDataInterface](#interface-consolidationoutputformattersstructureddatatabledatainterface), \IteratorAggregate, \Traversable, \ArrayAccess, \Serializable, \Countable*
 
 <hr />
 
@@ -751,6 +794,7 @@
 | public | <strong>isList()</strong> : <em>bool</em> |
 | public | <strong>setLayout(</strong><em>mixed</em> <strong>$layout</strong>)</strong> : <em>void</em> |
 | public | <strong>setOriginalData(</strong><em>[\Consolidation\OutputFormatters\StructuredData\MetadataHolderInterface](#interface-consolidationoutputformattersstructureddatametadataholderinterface)</em> <strong>$data</strong>)</strong> : <em>void</em> |
+| public | <strong>simplifyToString(</strong><em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>void</em><br /><em>simplifyToString is called by the string formatter to convert structured data to a simple string.</em> |
 | protected | <strong>convertTableToList()</strong> : <em>void</em> |
 | protected | <strong>getRowDataWithKey(</strong><em>mixed</em> <strong>$data</strong>)</strong> : <em>mixed</em> |
 | protected static | <strong>transformRow(</strong><em>mixed</em> <strong>$row</strong>, <em>mixed</em> <strong>$fieldLabels</strong>)</strong> : <em>void</em> |
@@ -758,7 +802,24 @@
 
 *This class extends \ArrayObject*
 
-*This class implements \Countable, \Serializable, \ArrayAccess, \Traversable, \IteratorAggregate, [\Consolidation\OutputFormatters\StructuredData\TableDataInterface](#interface-consolidationoutputformattersstructureddatatabledatainterface), [\Consolidation\OutputFormatters\StructuredData\OriginalDataInterface](#interface-consolidationoutputformattersstructureddataoriginaldatainterface)*
+*This class implements \Countable, \Serializable, \ArrayAccess, \Traversable, \IteratorAggregate, [\Consolidation\OutputFormatters\StructuredData\TableDataInterface](#interface-consolidationoutputformattersstructureddatatabledatainterface), [\Consolidation\OutputFormatters\Transformations\SimplifyToStringInterface](#interface-consolidationoutputformatterstransformationssimplifytostringinterface), [\Consolidation\OutputFormatters\StructuredData\OriginalDataInterface](#interface-consolidationoutputformattersstructureddataoriginaldatainterface)*
+
+<hr />
+
+### Class: \Consolidation\OutputFormatters\Transformations\UnstructuredDataTransformation
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>__construct(</strong><em>mixed</em> <strong>$data</strong>, <em>mixed</em> <strong>$fields</strong>)</strong> : <em>void</em> |
+| public | <strong>simplifyToString(</strong><em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>void</em> |
+| protected | <strong>isSimpleArray(</strong><em>mixed</em> <strong>$row</strong>)</strong> : <em>bool</em> |
+| protected | <strong>simplifyRow(</strong><em>mixed</em> <strong>$row</strong>)</strong> : <em>void</em> |
+| protected static | <strong>transformRow(</strong><em>mixed</em> <strong>$row</strong>, <em>mixed</em> <strong>$fields</strong>)</strong> : <em>void</em> |
+| protected static | <strong>transformRows(</strong><em>mixed</em> <strong>$data</strong>, <em>mixed</em> <strong>$fields</strong>)</strong> : <em>void</em> |
+
+*This class extends \ArrayObject*
+
+*This class implements \Countable, \Serializable, \ArrayAccess, \Traversable, \IteratorAggregate, [\Consolidation\OutputFormatters\Transformations\SimplifyToStringInterface](#interface-consolidationoutputformatterstransformationssimplifytostringinterface)*
 
 <hr />
 

--- a/scenarios/install
+++ b/scenarios/install
@@ -17,9 +17,17 @@ case $DEPENDENCIES in
     ;;
 esac
 
+original_name=scenarios
+recommended_name=".scenarios.lock"
+
+base="$original_name"
+if [ -d "$recommended_name" ] ; then
+  base="$recommended_name"
+fi
+
 # If scenario is not specified, install the lockfile at
 # the root of the project.
-dir=scenarios/${SCENARIO}
+dir="$base/${SCENARIO}"
 if [ -z "$SCENARIO" ] || [ "$SCENARIO" == "default" ] ; then
   SCENARIO=default
   dir=.
@@ -41,4 +49,9 @@ set -ex
 
 composer -n validate --working-dir=$dir --no-check-all --ansi
 composer -n --working-dir=$dir ${DEPENDENCIES} --prefer-dist --no-scripts
-composer -n --working-dir=$dir info
+
+# If called from a CI context, print out some extra information about
+# what we just installed.
+if [[ -n "$CI" ]] ; then
+  composer -n --working-dir=$dir info
+fi

--- a/scenarios/symfony2/composer.json
+++ b/scenarios/symfony2/composer.json
@@ -20,6 +20,7 @@
     },
     "require": {
         "php": ">=5.4.0",
+        "dflydev/dot-access-data": "^1.1.0",
         "symfony/finder": "^2.5|^3|^4"
     },
     "require-dev": {

--- a/scenarios/symfony3/composer.json
+++ b/scenarios/symfony3/composer.json
@@ -19,7 +19,8 @@
         }
     },
     "require": {
-        "php": ">=5.4.0"
+        "php": ">=5.4.0",
+        "dflydev/dot-access-data": "^1.1.0"
     },
     "require-dev": {
         "g1a/composer-test-scenarios": "^2",

--- a/scenarios/symfony3/composer.lock
+++ b/scenarios/symfony3/composer.lock
@@ -4,8 +4,68 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3bab8f4eb12ebe2704b58d1ba5e11e1e",
-    "packages": [],
+    "content-hash": "d004052ac5085a7f2de5d431ed168686",
+    "packages": [
+        {
+            "name": "dflydev/dot-access-data",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dflydev/dflydev-dot-access-data.git",
+                "reference": "3fbd874921ab2c041e899d044585a2ab9795df8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dflydev/dflydev-dot-access-data/zipball/3fbd874921ab2c041e899d044585a2ab9795df8a",
+                "reference": "3fbd874921ab2c041e899d044585a2ab9795df8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Dflydev\\DotAccessData": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dragonfly Development Inc.",
+                    "email": "info@dflydev.com",
+                    "homepage": "http://dflydev.com"
+                },
+                {
+                    "name": "Beau Simensen",
+                    "email": "beau@dflydev.com",
+                    "homepage": "http://beausimensen.com"
+                },
+                {
+                    "name": "Carlos Frutos",
+                    "email": "carlos@kiwing.it",
+                    "homepage": "https://github.com/cfrutos"
+                }
+            ],
+            "description": "Given a deep data structure, access data by dot notation.",
+            "homepage": "https://github.com/dflydev/dflydev-dot-access-data",
+            "keywords": [
+                "access",
+                "data",
+                "dot",
+                "notation"
+            ],
+            "time": "2017-01-20T21:14:22+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",

--- a/scenarios/symfony3/composer.lock
+++ b/scenarios/symfony3/composer.lock
@@ -63,16 +63,16 @@
         },
         {
             "name": "g1a/composer-test-scenarios",
-            "version": "2.0.1",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/g1a/composer-test-scenarios.git",
-                "reference": "d9a7619f6e1c01498fad19c34539bd5b0d2506ef"
+                "reference": "a166fd15191aceab89f30c097e694b7cf3db4880"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/g1a/composer-test-scenarios/zipball/d9a7619f6e1c01498fad19c34539bd5b0d2506ef",
-                "reference": "d9a7619f6e1c01498fad19c34539bd5b0d2506ef",
+                "url": "https://api.github.com/repos/g1a/composer-test-scenarios/zipball/a166fd15191aceab89f30c097e694b7cf3db4880",
+                "reference": "a166fd15191aceab89f30c097e694b7cf3db4880",
                 "shasum": ""
             },
             "bin": [
@@ -92,7 +92,7 @@
                 }
             ],
             "description": "Useful scripts for testing multiple sets of Composer dependencies.",
-            "time": "2018-05-25T16:45:48+00:00"
+            "time": "2018-08-08T23:37:23+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -468,16 +468,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.7.6",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712"
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
-                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
                 "shasum": ""
             },
             "require": {
@@ -489,12 +489,12 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7.x-dev"
+                    "dev-master": "1.8.x-dev"
                 }
             },
             "autoload": {
@@ -527,7 +527,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-04-18T13:57:24+00:00"
+            "time": "2018-08-05T17:53:17+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1693,16 +1693,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v3.4.11",
+            "version": "v3.4.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "73e055cf2e6467715f187724a0347ea32079967c"
+                "reference": "e5389132dc6320682de3643091121c048ff796b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/73e055cf2e6467715f187724a0347ea32079967c",
-                "reference": "73e055cf2e6467715f187724a0347ea32079967c",
+                "url": "https://api.github.com/repos/symfony/config/zipball/e5389132dc6320682de3643091121c048ff796b3",
+                "reference": "e5389132dc6320682de3643091121c048ff796b3",
                 "shasum": ""
             },
             "require": {
@@ -1753,20 +1753,20 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2018-05-14T16:49:53+00:00"
+            "time": "2018-09-08T13:15:14+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v3.4.11",
+            "version": "v3.4.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "36f83f642443c46f3cf751d4d2ee5d047d757a27"
+                "reference": "3b2b415d4c48fbefca7dc742aa0a0171bfae4e0b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/36f83f642443c46f3cf751d4d2ee5d047d757a27",
-                "reference": "36f83f642443c46f3cf751d4d2ee5d047d757a27",
+                "url": "https://api.github.com/repos/symfony/console/zipball/3b2b415d4c48fbefca7dc742aa0a0171bfae4e0b",
+                "reference": "3b2b415d4c48fbefca7dc742aa0a0171bfae4e0b",
                 "shasum": ""
             },
             "require": {
@@ -1822,20 +1822,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2018-05-16T08:49:21+00:00"
+            "time": "2018-10-02T16:33:53+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.4.11",
+            "version": "v3.4.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "b28fd73fefbac341f673f5efd707d539d6a19f68"
+                "reference": "0a612e9dfbd2ccce03eb174365f31ecdca930ff6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/b28fd73fefbac341f673f5efd707d539d6a19f68",
-                "reference": "b28fd73fefbac341f673f5efd707d539d6a19f68",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/0a612e9dfbd2ccce03eb174365f31ecdca930ff6",
+                "reference": "0a612e9dfbd2ccce03eb174365f31ecdca930ff6",
                 "shasum": ""
             },
             "require": {
@@ -1878,20 +1878,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2018-05-16T14:03:39+00:00"
+            "time": "2018-10-02T16:33:53+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.4.11",
+            "version": "v3.4.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "8e03ca3fa52a0f56b87506f38cf7bd3f9442b3a0"
+                "reference": "d69930fc337d767607267d57c20a7403d0a822a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/8e03ca3fa52a0f56b87506f38cf7bd3f9442b3a0",
-                "reference": "8e03ca3fa52a0f56b87506f38cf7bd3f9442b3a0",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d69930fc337d767607267d57c20a7403d0a822a4",
+                "reference": "d69930fc337d767607267d57c20a7403d0a822a4",
                 "shasum": ""
             },
             "require": {
@@ -1928,20 +1928,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2018-05-16T08:49:21+00:00"
+            "time": "2018-10-02T12:28:39+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.4.11",
+            "version": "v3.4.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "472a92f3df8b247b49ae364275fb32943b9656c6"
+                "reference": "54ba444dddc5bd5708a34bd095ea67c6eb54644d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/472a92f3df8b247b49ae364275fb32943b9656c6",
-                "reference": "472a92f3df8b247b49ae364275fb32943b9656c6",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/54ba444dddc5bd5708a34bd095ea67c6eb54644d",
+                "reference": "54ba444dddc5bd5708a34bd095ea67c6eb54644d",
                 "shasum": ""
             },
             "require": {
@@ -1977,29 +1977,32 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2018-05-16T08:49:21+00:00"
+            "time": "2018-10-03T08:46:40+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.8.0",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae"
+                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
-                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e3d826245268269cd66f8326bd8bc066687b4a19",
+                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8-dev"
+                    "dev-master": "1.9-dev"
                 }
             },
             "autoload": {
@@ -2032,20 +2035,20 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2018-04-30T19:57:29+00:00"
+            "time": "2018-08-06T14:22:27+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.8.0",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "3296adf6a6454a050679cde90f95350ad604b171"
+                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/3296adf6a6454a050679cde90f95350ad604b171",
-                "reference": "3296adf6a6454a050679cde90f95350ad604b171",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d0cd638f4634c16d8df4508e847f14e9e43168b8",
+                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8",
                 "shasum": ""
             },
             "require": {
@@ -2057,7 +2060,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8-dev"
+                    "dev-master": "1.9-dev"
                 }
             },
             "autoload": {
@@ -2091,20 +2094,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-04-26T10:06:28+00:00"
+            "time": "2018-08-06T14:22:27+00:00"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v3.4.11",
+            "version": "v3.4.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "eb17cfa072cab26537ac37e9c4ece6c0361369af"
+                "reference": "05e52a39de52ba690aebaed462b2bc8a9649f0a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/eb17cfa072cab26537ac37e9c4ece6c0361369af",
-                "reference": "eb17cfa072cab26537ac37e9c4ece6c0361369af",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/05e52a39de52ba690aebaed462b2bc8a9649f0a4",
+                "reference": "05e52a39de52ba690aebaed462b2bc8a9649f0a4",
                 "shasum": ""
             },
             "require": {
@@ -2140,20 +2143,20 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2018-02-17T14:55:25+00:00"
+            "time": "2018-10-02T12:28:39+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v3.4.11",
+            "version": "v3.4.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "0e6545672d8c9ce70dd472adc2f8b03155a46f73"
+                "reference": "ff8ac19e97e5c7c3979236b584719a1190f84181"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/0e6545672d8c9ce70dd472adc2f8b03155a46f73",
-                "reference": "0e6545672d8c9ce70dd472adc2f8b03155a46f73",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/ff8ac19e97e5c7c3979236b584719a1190f84181",
+                "reference": "ff8ac19e97e5c7c3979236b584719a1190f84181",
                 "shasum": ""
             },
             "require": {
@@ -2209,20 +2212,20 @@
                 "debug",
                 "dump"
             ],
-            "time": "2018-04-26T12:42:15+00:00"
+            "time": "2018-10-02T16:33:53+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.4.11",
+            "version": "v3.4.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "c5010cc1692ce1fa328b1fb666961eb3d4a85bb0"
+                "reference": "640b6c27fed4066d64b64d5903a86043f4a4de7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/c5010cc1692ce1fa328b1fb666961eb3d4a85bb0",
-                "reference": "c5010cc1692ce1fa328b1fb666961eb3d4a85bb0",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/640b6c27fed4066d64b64d5903a86043f4a4de7f",
+                "reference": "640b6c27fed4066d64b64d5903a86043f4a4de7f",
                 "shasum": ""
             },
             "require": {
@@ -2268,7 +2271,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2018-05-03T23:18:14+00:00"
+            "time": "2018-10-02T16:33:53+00:00"
         },
         {
             "name": "victorjonsson/markdowndocs",

--- a/scenarios/symfony4/composer.json
+++ b/scenarios/symfony4/composer.json
@@ -20,6 +20,7 @@
     },
     "require": {
         "php": ">=5.4.0",
+        "dflydev/dot-access-data": "^1.1.0",
         "symfony/finder": "^2.5|^3|^4"
     },
     "require-dev": {

--- a/scenarios/symfony4/composer.lock
+++ b/scenarios/symfony4/composer.lock
@@ -4,8 +4,67 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5cf6dbee97ee4ebf85fdf88113ee26ea",
+    "content-hash": "bdf887c1a61b990bc779974fc940c095",
     "packages": [
+        {
+            "name": "dflydev/dot-access-data",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dflydev/dflydev-dot-access-data.git",
+                "reference": "3fbd874921ab2c041e899d044585a2ab9795df8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dflydev/dflydev-dot-access-data/zipball/3fbd874921ab2c041e899d044585a2ab9795df8a",
+                "reference": "3fbd874921ab2c041e899d044585a2ab9795df8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Dflydev\\DotAccessData": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dragonfly Development Inc.",
+                    "email": "info@dflydev.com",
+                    "homepage": "http://dflydev.com"
+                },
+                {
+                    "name": "Beau Simensen",
+                    "email": "beau@dflydev.com",
+                    "homepage": "http://beausimensen.com"
+                },
+                {
+                    "name": "Carlos Frutos",
+                    "email": "carlos@kiwing.it",
+                    "homepage": "https://github.com/cfrutos"
+                }
+            ],
+            "description": "Given a deep data structure, access data by dot notation.",
+            "homepage": "https://github.com/dflydev/dflydev-dot-access-data",
+            "keywords": [
+                "access",
+                "data",
+                "dot",
+                "notation"
+            ],
+            "time": "2017-01-20T21:14:22+00:00"
+        },
         {
             "name": "symfony/finder",
             "version": "v4.1.6",

--- a/scenarios/symfony4/composer.lock
+++ b/scenarios/symfony4/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "symfony/finder",
-            "version": "v4.0.11",
+            "version": "v4.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "8c633f5a815903a1fe6e3fc135f207267a8a79af"
+                "reference": "1f17195b44543017a9c9b2d437c670627e96ad06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/8c633f5a815903a1fe6e3fc135f207267a8a79af",
-                "reference": "8c633f5a815903a1fe6e3fc135f207267a8a79af",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/1f17195b44543017a9c9b2d437c670627e96ad06",
+                "reference": "1f17195b44543017a9c9b2d437c670627e96ad06",
                 "shasum": ""
             },
             "require": {
@@ -26,7 +26,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
@@ -53,7 +53,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2018-05-16T09:05:32+00:00"
+            "time": "2018-10-03T08:47:56+00:00"
         }
     ],
     "packages-dev": [
@@ -113,16 +113,16 @@
         },
         {
             "name": "g1a/composer-test-scenarios",
-            "version": "2.0.1",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/g1a/composer-test-scenarios.git",
-                "reference": "d9a7619f6e1c01498fad19c34539bd5b0d2506ef"
+                "reference": "a166fd15191aceab89f30c097e694b7cf3db4880"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/g1a/composer-test-scenarios/zipball/d9a7619f6e1c01498fad19c34539bd5b0d2506ef",
-                "reference": "d9a7619f6e1c01498fad19c34539bd5b0d2506ef",
+                "url": "https://api.github.com/repos/g1a/composer-test-scenarios/zipball/a166fd15191aceab89f30c097e694b7cf3db4880",
+                "reference": "a166fd15191aceab89f30c097e694b7cf3db4880",
                 "shasum": ""
             },
             "bin": [
@@ -142,7 +142,7 @@
                 }
             ],
             "description": "Useful scripts for testing multiple sets of Composer dependencies.",
-            "time": "2018-05-25T16:45:48+00:00"
+            "time": "2018-08-08T23:37:23+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -327,25 +327,28 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.7.0",
+            "version": "1.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
+                "reference": "3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8",
+                "reference": "3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.1"
+            },
+            "replace": {
+                "myclabs/deep-copy": "self.version"
             },
             "require-dev": {
                 "doctrine/collections": "^1.0",
                 "doctrine/common": "^2.6",
-                "phpunit/phpunit": "^4.1"
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "autoload": {
@@ -368,7 +371,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-10-19T19:58:43+00:00"
+            "time": "2018-06-11T23:09:50+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -626,16 +629,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.7.6",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712"
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
-                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
                 "shasum": ""
             },
             "require": {
@@ -647,12 +650,12 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7.x-dev"
+                    "dev-master": "1.8.x-dev"
                 }
             },
             "autoload": {
@@ -685,7 +688,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-04-18T13:57:24+00:00"
+            "time": "2018-08-05T17:53:17+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -938,16 +941,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.5.8",
+            "version": "6.5.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "4f21a3c6b97c42952fd5c2837bb354ec0199b97b"
+                "reference": "0973426fb012359b2f18d3bd1e90ef1172839693"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/4f21a3c6b97c42952fd5c2837bb354ec0199b97b",
-                "reference": "4f21a3c6b97c42952fd5c2837bb354ec0199b97b",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0973426fb012359b2f18d3bd1e90ef1172839693",
+                "reference": "0973426fb012359b2f18d3bd1e90ef1172839693",
                 "shasum": ""
             },
             "require": {
@@ -965,7 +968,7 @@
                 "phpunit/php-file-iterator": "^1.4.3",
                 "phpunit/php-text-template": "^1.2.1",
                 "phpunit/php-timer": "^1.0.9",
-                "phpunit/phpunit-mock-objects": "^5.0.5",
+                "phpunit/phpunit-mock-objects": "^5.0.9",
                 "sebastian/comparator": "^2.1",
                 "sebastian/diff": "^2.0",
                 "sebastian/environment": "^3.1",
@@ -1018,20 +1021,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-04-10T11:38:34+00:00"
+            "time": "2018-09-08T15:10:43+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "5.0.6",
+            "version": "5.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "33fd41a76e746b8fa96d00b49a23dadfa8334cdf"
+                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/33fd41a76e746b8fa96d00b49a23dadfa8334cdf",
-                "reference": "33fd41a76e746b8fa96d00b49a23dadfa8334cdf",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/cd1cf05c553ecfec36b170070573e540b67d3f1f",
+                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f",
                 "shasum": ""
             },
             "require": {
@@ -1044,7 +1047,7 @@
                 "phpunit/phpunit": "<6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.5"
+                "phpunit/phpunit": "^6.5.11"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -1077,7 +1080,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2018-01-06T05:45:45+00:00"
+            "time": "2018-08-09T05:50:03+00:00"
         },
         {
             "name": "psr/http-message",
@@ -1899,16 +1902,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v4.0.11",
+            "version": "v4.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "aaef656e99c5396d6118970abd1ceb11fa74551d"
+                "reference": "b3d4d7b567d7a49e6dfafb6d4760abc921177c96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/aaef656e99c5396d6118970abd1ceb11fa74551d",
-                "reference": "aaef656e99c5396d6118970abd1ceb11fa74551d",
+                "url": "https://api.github.com/repos/symfony/config/zipball/b3d4d7b567d7a49e6dfafb6d4760abc921177c96",
+                "reference": "b3d4d7b567d7a49e6dfafb6d4760abc921177c96",
                 "shasum": ""
             },
             "require": {
@@ -1931,7 +1934,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
@@ -1958,20 +1961,20 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2018-05-16T09:05:32+00:00"
+            "time": "2018-09-08T13:24:10+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v4.0.11",
+            "version": "v4.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "058f120b8e06ebcd7b211de5ffae07b2db00fbdd"
+                "reference": "dc7122fe5f6113cfaba3b3de575d31112c9aa60b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/058f120b8e06ebcd7b211de5ffae07b2db00fbdd",
-                "reference": "058f120b8e06ebcd7b211de5ffae07b2db00fbdd",
+                "url": "https://api.github.com/repos/symfony/console/zipball/dc7122fe5f6113cfaba3b3de575d31112c9aa60b",
+                "reference": "dc7122fe5f6113cfaba3b3de575d31112c9aa60b",
                 "shasum": ""
             },
             "require": {
@@ -1999,7 +2002,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
@@ -2026,20 +2029,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2018-05-16T09:05:32+00:00"
+            "time": "2018-10-03T08:15:46+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v4.0.11",
+            "version": "v4.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "7a69e728e9f0044958c2fd7d72bfe5e7bd1a4d04"
+                "reference": "596d12b40624055c300c8b619755b748ca5cf0b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/7a69e728e9f0044958c2fd7d72bfe5e7bd1a4d04",
-                "reference": "7a69e728e9f0044958c2fd7d72bfe5e7bd1a4d04",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/596d12b40624055c300c8b619755b748ca5cf0b5",
+                "reference": "596d12b40624055c300c8b619755b748ca5cf0b5",
                 "shasum": ""
             },
             "require": {
@@ -2049,7 +2052,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
@@ -2076,29 +2079,32 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2018-05-16T09:05:32+00:00"
+            "time": "2018-10-02T12:40:59+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.8.0",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae"
+                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
-                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e3d826245268269cd66f8326bd8bc066687b4a19",
+                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8-dev"
+                    "dev-master": "1.9-dev"
                 }
             },
             "autoload": {
@@ -2131,20 +2137,20 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2018-04-30T19:57:29+00:00"
+            "time": "2018-08-06T14:22:27+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.8.0",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "3296adf6a6454a050679cde90f95350ad604b171"
+                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/3296adf6a6454a050679cde90f95350ad604b171",
-                "reference": "3296adf6a6454a050679cde90f95350ad604b171",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d0cd638f4634c16d8df4508e847f14e9e43168b8",
+                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8",
                 "shasum": ""
             },
             "require": {
@@ -2156,7 +2162,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8-dev"
+                    "dev-master": "1.9-dev"
                 }
             },
             "autoload": {
@@ -2190,20 +2196,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-04-26T10:06:28+00:00"
+            "time": "2018-08-06T14:22:27+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.8.0",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "a4576e282d782ad82397f3e4ec1df8e0f0cafb46"
+                "reference": "95c50420b0baed23852452a7f0c7b527303ed5ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/a4576e282d782ad82397f3e4ec1df8e0f0cafb46",
-                "reference": "a4576e282d782ad82397f3e4ec1df8e0f0cafb46",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/95c50420b0baed23852452a7f0c7b527303ed5ae",
+                "reference": "95c50420b0baed23852452a7f0c7b527303ed5ae",
                 "shasum": ""
             },
             "require": {
@@ -2212,7 +2218,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8-dev"
+                    "dev-master": "1.9-dev"
                 }
             },
             "autoload": {
@@ -2245,20 +2251,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-04-26T10:06:28+00:00"
+            "time": "2018-08-06T14:22:27+00:00"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v4.0.11",
+            "version": "v4.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "6795ffa2f8eebedac77f045aa62c0c10b2763042"
+                "reference": "5bfc064125b73ff81229e19381ce1c34d3416f4b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/6795ffa2f8eebedac77f045aa62c0c10b2763042",
-                "reference": "6795ffa2f8eebedac77f045aa62c0c10b2763042",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/5bfc064125b73ff81229e19381ce1c34d3416f4b",
+                "reference": "5bfc064125b73ff81229e19381ce1c34d3416f4b",
                 "shasum": ""
             },
             "require": {
@@ -2267,7 +2273,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
@@ -2294,20 +2300,20 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2018-02-19T16:50:22+00:00"
+            "time": "2018-10-02T12:40:59+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v4.0.11",
+            "version": "v4.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "3c34cf3f4bbac9e003d9325225e9ef1a49180a18"
+                "reference": "60319b45653580b0cdacca499344577d87732f16"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/3c34cf3f4bbac9e003d9325225e9ef1a49180a18",
-                "reference": "3c34cf3f4bbac9e003d9325225e9ef1a49180a18",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/60319b45653580b0cdacca499344577d87732f16",
+                "reference": "60319b45653580b0cdacca499344577d87732f16",
                 "shasum": ""
             },
             "require": {
@@ -2316,20 +2322,26 @@
                 "symfony/polyfill-php72": "~1.5"
             },
             "conflict": {
-                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
+                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",
+                "symfony/console": "<3.4"
             },
             "require-dev": {
                 "ext-iconv": "*",
+                "symfony/process": "~3.4|~4.0",
                 "twig/twig": "~1.34|~2.4"
             },
             "suggest": {
                 "ext-iconv": "To convert non-UTF-8 strings to UTF-8 (or symfony/polyfill-iconv in case ext-iconv cannot be used).",
-                "ext-intl": "To show region name in time zone dump"
+                "ext-intl": "To show region name in time zone dump",
+                "symfony/console": "To use the ServerDumpCommand and/or the bin/var-dump-server script"
             },
+            "bin": [
+                "Resources/bin/var-dump-server"
+            ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
@@ -2363,20 +2375,20 @@
                 "debug",
                 "dump"
             ],
-            "time": "2018-04-26T16:12:06+00:00"
+            "time": "2018-10-02T16:36:10+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v4.0.11",
+            "version": "v4.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "048b1be5fb96e73ff1d065f5e7e23f84415ac907"
+                "reference": "367e689b2fdc19965be435337b50bc8adf2746c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/048b1be5fb96e73ff1d065f5e7e23f84415ac907",
-                "reference": "048b1be5fb96e73ff1d065f5e7e23f84415ac907",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/367e689b2fdc19965be435337b50bc8adf2746c9",
+                "reference": "367e689b2fdc19965be435337b50bc8adf2746c9",
                 "shasum": ""
             },
             "require": {
@@ -2395,7 +2407,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
@@ -2422,7 +2434,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2018-05-07T07:12:24+00:00"
+            "time": "2018-10-02T16:36:10+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/src/FormatterManager.php
+++ b/src/FormatterManager.php
@@ -19,6 +19,7 @@ use Consolidation\OutputFormatters\Validate\ValidationInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Consolidation\OutputFormatters\StructuredData\OriginalDataInterface;
+use Consolidation\OutputFormatters\StructuredData\ListDataFromKeys;
 
 /**
  * Manage a collection of formatters; return one on request.
@@ -121,10 +122,18 @@ class FormatterManager
             $automaticOptions[FormatterOptions::FORMAT] = new InputOption(FormatterOptions::FORMAT, '', InputOption::VALUE_REQUIRED, $description, $defaultFormat);
         }
 
+        $dataTypeClass = ($dataType instanceof \ReflectionClass) ? $dataType : new \ReflectionClass($dataType);
+
         if ($availableFields) {
             $defaultFields = $options->get(FormatterOptions::DEFAULT_FIELDS, [], '');
             $description = 'Available fields: ' . implode(', ', $this->availableFieldsList($availableFields));
             $automaticOptions[FormatterOptions::FIELDS] = new InputOption(FormatterOptions::FIELDS, '', InputOption::VALUE_REQUIRED, $description, $defaultFields);
+        }
+        elseif ($dataTypeClass->implementsInterface(RestructureInterface::class)) {
+            $automaticOptions[FormatterOptions::FIELDS] = new InputOption(FormatterOptions::FIELDS, '', InputOption::VALUE_REQUIRED, 'Dot notation of fields to include in output.', []);
+        }
+
+        if (isset($automaticOptions[FormatterOptions::FIELDS])) {
             $automaticOptions[FormatterOptions::FIELD] = new InputOption(FormatterOptions::FIELD, '', InputOption::VALUE_REQUIRED, "Select just one field, and force format to 'string'.", '');
         }
 

--- a/src/FormatterManager.php
+++ b/src/FormatterManager.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Consolidation\OutputFormatters\StructuredData\OriginalDataInterface;
 use Consolidation\OutputFormatters\StructuredData\ListDataFromKeys;
+use Consolidation\OutputFormatters\StructuredData\ConversionInterface;
 
 /**
  * Manage a collection of formatters; return one on request.

--- a/src/FormatterManager.php
+++ b/src/FormatterManager.php
@@ -128,8 +128,7 @@ class FormatterManager
             $defaultFields = $options->get(FormatterOptions::DEFAULT_FIELDS, [], '');
             $description = 'Available fields: ' . implode(', ', $this->availableFieldsList($availableFields));
             $automaticOptions[FormatterOptions::FIELDS] = new InputOption(FormatterOptions::FIELDS, '', InputOption::VALUE_REQUIRED, $description, $defaultFields);
-        }
-        elseif ($dataTypeClass->implementsInterface(RestructureInterface::class)) {
+        } elseif ($dataTypeClass->implementsInterface('Consolidation\OutputFormatters\StructuredData\RestructureInterface')) {
             $automaticOptions[FormatterOptions::FIELDS] = new InputOption(FormatterOptions::FIELDS, '', InputOption::VALUE_REQUIRED, 'Dot notation of fields to include in output.', []);
         }
 

--- a/src/Formatters/CsvFormatter.php
+++ b/src/Formatters/CsvFormatter.php
@@ -30,6 +30,7 @@ class CsvFormatter implements FormatterInterface, ValidDataTypesInterface, Rende
             [
                 new \ReflectionClass('\Consolidation\OutputFormatters\StructuredData\RowsOfFields'),
                 new \ReflectionClass('\Consolidation\OutputFormatters\StructuredData\PropertyList'),
+                new \ReflectionClass('\ArrayObject'),
             ];
     }
 

--- a/src/Formatters/CsvFormatter.php
+++ b/src/Formatters/CsvFormatter.php
@@ -30,7 +30,6 @@ class CsvFormatter implements FormatterInterface, ValidDataTypesInterface, Rende
             [
                 new \ReflectionClass('\Consolidation\OutputFormatters\StructuredData\RowsOfFields'),
                 new \ReflectionClass('\Consolidation\OutputFormatters\StructuredData\PropertyList'),
-                new \ReflectionClass('\ArrayObject'),
             ];
     }
 

--- a/src/Formatters/StringFormatter.php
+++ b/src/Formatters/StringFormatter.php
@@ -7,6 +7,8 @@ use Consolidation\OutputFormatters\Options\FormatterOptions;
 use Consolidation\OutputFormatters\Validate\ValidDataTypesTrait;
 use Symfony\Component\Console\Output\OutputInterface;
 use Consolidation\OutputFormatters\StructuredData\RestructureInterface;
+use Consolidation\OutputFormatters\Transformations\SimplifiedFormatterInterface;
+use Consolidation\OutputFormatters\Transformations\SimplifyToStringInterface;
 
 /**
  * String formatter
@@ -53,7 +55,7 @@ class StringFormatter implements FormatterInterface, ValidationInterface, Overri
 
     /**
      * If the data provided to a 'string' formatter is a table, then try
-     * to emit it as a TSV value.
+     * to emit it in a simplified form (by default, TSV).
      *
      * @param OutputInterface $output
      * @param mixed $data
@@ -61,6 +63,11 @@ class StringFormatter implements FormatterInterface, ValidationInterface, Overri
      */
     protected function reduceToSigleFieldAndWrite(OutputInterface $output, $data, FormatterOptions $options)
     {
+        if ($data instanceof SimplifyToStringInterface) {
+            $simplified = $data->simplifyToString($options);
+            return $output->write($simplified);
+        }
+
         $alternateFormatter = new TsvFormatter();
         try {
             $data = $alternateFormatter->validate($data);

--- a/src/Formatters/StringFormatter.php
+++ b/src/Formatters/StringFormatter.php
@@ -8,7 +8,7 @@ use Consolidation\OutputFormatters\Validate\ValidDataTypesTrait;
 use Symfony\Component\Console\Output\OutputInterface;
 use Consolidation\OutputFormatters\StructuredData\RestructureInterface;
 use Consolidation\OutputFormatters\Transformations\SimplifiedFormatterInterface;
-use Consolidation\OutputFormatters\Transformations\SimplifyToStringInterface;
+use Consolidation\OutputFormatters\Transformations\StringTransformationInterface;
 
 /**
  * String formatter
@@ -63,7 +63,7 @@ class StringFormatter implements FormatterInterface, ValidationInterface, Overri
      */
     protected function reduceToSigleFieldAndWrite(OutputInterface $output, $data, FormatterOptions $options)
     {
-        if ($data instanceof SimplifyToStringInterface) {
+        if ($data instanceof StringTransformationInterface) {
             $simplified = $data->simplifyToString($options);
             return $output->write($simplified);
         }

--- a/src/StructuredData/AbstractListData.php
+++ b/src/StructuredData/AbstractListData.php
@@ -1,0 +1,61 @@
+<?php
+namespace Consolidation\OutputFormatters\StructuredData;
+
+use Consolidation\OutputFormatters\Options\FormatterOptions;
+use Consolidation\OutputFormatters\Transformations\ReorderFields;
+
+/**
+ * Base class for all list data types.
+ */
+class AbstractListData extends \ArrayObject implements ListDataInterface
+{
+    public function __construct($data)
+    {
+        parent::__construct($data);
+    }
+
+    public function getListData(FormatterOptions $options)
+    {
+        return array_keys($this->getArrayCopy());
+    }
+
+    protected function getReorderedFieldLabels($data, $options, $defaults)
+    {
+        $reorderer = new ReorderFields();
+        $fieldLabels = $reorderer->reorder(
+            $this->getFields($options, $defaults),
+            $options->get(FormatterOptions::FIELD_LABELS, $defaults),
+            $data
+        );
+        return $fieldLabels;
+    }
+
+    protected function getFields($options, $defaults)
+    {
+        $fieldShortcut = $options->get(FormatterOptions::FIELD);
+        if (!empty($fieldShortcut)) {
+            return [$fieldShortcut];
+        }
+        $result = $options->get(FormatterOptions::FIELDS, $defaults);
+        if (!empty($result)) {
+            return $result;
+        }
+        return $options->get(FormatterOptions::DEFAULT_FIELDS, $defaults);
+    }
+
+    /**
+     * A structured list may provide its own set of default options. These
+     * will be used in place of the command's default options (from the
+     * annotations) in instances where the user does not provide the options
+     * explicitly (on the commandline) or implicitly (via a configuration file).
+     *
+     * @return array
+     */
+    protected function defaultOptions()
+    {
+        return [
+            FormatterOptions::FIELDS => [],
+            FormatterOptions::FIELD_LABELS => [],
+        ];
+    }
+}

--- a/src/StructuredData/AbstractStructuredList.php
+++ b/src/StructuredData/AbstractStructuredList.php
@@ -4,7 +4,6 @@ namespace Consolidation\OutputFormatters\StructuredData;
 use Consolidation\OutputFormatters\StructuredData\RestructureInterface;
 use Consolidation\OutputFormatters\Options\FormatterOptions;
 use Consolidation\OutputFormatters\StructuredData\ListDataInterface;
-use Consolidation\OutputFormatters\Transformations\ReorderFields;
 use Consolidation\OutputFormatters\Transformations\TableTransformation;
 
 /**
@@ -14,7 +13,7 @@ use Consolidation\OutputFormatters\Transformations\TableTransformation;
  *
  * It is presumed that every row contains the same keys.
  */
-abstract class AbstractStructuredList extends ListDataFromKeys implements RestructureInterface, RenderCellCollectionInterface
+abstract class AbstractStructuredList extends AbstractListData implements RestructureInterface, RenderCellCollectionInterface
 {
     use RenderCellCollectionTrait;
 
@@ -43,45 +42,12 @@ abstract class AbstractStructuredList extends ListDataFromKeys implements Restru
         return new TableTransformation($data, $fieldLabels, $rowLabels);
     }
 
-    protected function getReorderedFieldLabels($data, $options, $defaults)
-    {
-        $reorderer = new ReorderFields();
-        $fieldLabels = $reorderer->reorder(
-            $this->getFields($options, $defaults),
-            $options->get(FormatterOptions::FIELD_LABELS, $defaults),
-            $data
-        );
-        return $fieldLabels;
-    }
-
-    protected function getFields($options, $defaults)
-    {
-        $fieldShortcut = $options->get(FormatterOptions::FIELD);
-        if (!empty($fieldShortcut)) {
-            return [$fieldShortcut];
-        }
-        $result = $options->get(FormatterOptions::FIELDS, $defaults);
-        if (!empty($result)) {
-            return $result;
-        }
-        return $options->get(FormatterOptions::DEFAULT_FIELDS, $defaults);
-    }
-
-    /**
-     * A structured list may provide its own set of default options. These
-     * will be used in place of the command's default options (from the
-     * annotations) in instances where the user does not provide the options
-     * explicitly (on the commandline) or implicitly (via a configuration file).
-     *
-     * @return array
-     */
     protected function defaultOptions()
     {
         return [
-            FormatterOptions::FIELDS => [],
-            FormatterOptions::FIELD_LABELS => [],
             FormatterOptions::ROW_LABELS => [],
             FormatterOptions::DEFAULT_FIELDS => [],
-        ];
+        ] + parent::defaultOptions();
     }
+
 }

--- a/src/StructuredData/AbstractStructuredList.php
+++ b/src/StructuredData/AbstractStructuredList.php
@@ -49,5 +49,4 @@ abstract class AbstractStructuredList extends AbstractListData implements Restru
             FormatterOptions::DEFAULT_FIELDS => [],
         ] + parent::defaultOptions();
     }
-
 }

--- a/src/StructuredData/ConversionInterface.php
+++ b/src/StructuredData/ConversionInterface.php
@@ -1,0 +1,15 @@
+<?php
+namespace Consolidation\OutputFormatters\StructuredData;
+
+use Consolidation\OutputFormatters\Options\FormatterOptions;
+
+interface ConversionInterface
+{
+    /**
+     * Allow structured data to be converted -- i.e. from
+     * RowsOfFields to UnstructuredListData.
+     *
+     * @param FormatterOptions $options Formatting options
+     */
+    public function convert(FormatterOptions $options);
+}

--- a/src/StructuredData/FieldProcessor.php
+++ b/src/StructuredData/FieldProcessor.php
@@ -23,7 +23,17 @@ class FieldProcessor
         return $transformed_fields;
     }
 
-    public static function hasUnstructuredFieldAccess($options)
+    /**
+     * Determine whether the data structure has unstructured field access,
+     * e.g. `a.b.c` or `foo as bar`.
+     * @param type $fields
+     * @return type
+     */
+    public static function hasUnstructuredFieldAccess($fields)
     {
+        if (is_array($fields)) {
+            $fields = implode(',', $fields);
+        }
+        return (strpos($fields, ' as ') !== false) || (strpos($fields, '.') !== false);
     }
 }

--- a/src/StructuredData/FieldProcessor.php
+++ b/src/StructuredData/FieldProcessor.php
@@ -22,4 +22,8 @@ class FieldProcessor
         }
         return $transformed_fields;
     }
+
+    public static function hasUnstructuredFieldAccess($options)
+    {
+    }
 }

--- a/src/StructuredData/FieldProcessor.php
+++ b/src/StructuredData/FieldProcessor.php
@@ -1,0 +1,25 @@
+<?php
+namespace Consolidation\OutputFormatters\StructuredData;
+
+use Consolidation\OutputFormatters\Options\FormatterOptions;
+use Consolidation\OutputFormatters\StructuredData\RestructureInterface;
+use Consolidation\OutputFormatters\Transformations\UnstructuredDataListTransformation;
+
+/**
+ * FieldProcessor will do various alterations on field sets.
+ */
+class FieldProcessor
+{
+    public static function processFieldAliases($fields)
+    {
+        if (!is_array($fields)) {
+            $fields = array_filter(explode(',', $fields));
+        }
+        $transformed_fields = [];
+        foreach ($fields as $field) {
+            list($machine_name,$label) = explode(' as ', $field) + [$field, preg_replace('#.*\.#', '', $field)];
+            $transformed_fields[$machine_name] = $label;
+        }
+        return $transformed_fields;
+    }
+}

--- a/src/StructuredData/ListDataFromKeys.php
+++ b/src/StructuredData/ListDataFromKeys.php
@@ -1,21 +1,9 @@
 <?php
 namespace Consolidation\OutputFormatters\StructuredData;
 
-use Consolidation\OutputFormatters\Options\FormatterOptions;
-
 /**
- * Represents aribtrary array data (structured or unstructured) where the
- * data to display in --list format comes from the array keys.
+ * @deprecated Use UnstructuredListData
  */
-class ListDataFromKeys extends \ArrayObject implements ListDataInterface
+class ListDataFromKeys extends AbstractListData
 {
-    public function __construct($data)
-    {
-        parent::__construct($data);
-    }
-
-    public function getListData(FormatterOptions $options)
-    {
-        return array_keys($this->getArrayCopy());
-    }
 }

--- a/src/StructuredData/PropertyList.php
+++ b/src/StructuredData/PropertyList.php
@@ -13,8 +13,21 @@ use Consolidation\OutputFormatters\Transformations\PropertyListTableTransformati
  * key : value pair.  The keys must be unique, as is typically
  * the case for associative arrays.
  */
-class PropertyList extends AbstractStructuredList
+class PropertyList extends AbstractStructuredList implements ConversionInterface
 {
+    /**
+     * @inheritdoc
+     */
+    public function convert(FormatterOptions $options)
+    {
+        $defaults = $this->defaultOptions();
+        $fields = $this->getFields($options, $defaults);
+        if (FieldProcessor::hasUnstructuredFieldAccess($fields)) {
+            return new UnstructuredData($this->getArrayCopy());
+        }
+        return $this;
+    }
+
     /**
      * Restructure this data for output by converting it into a table
      * transformation object.

--- a/src/StructuredData/RowsOfFields.php
+++ b/src/StructuredData/RowsOfFields.php
@@ -10,8 +10,21 @@ use Consolidation\OutputFormatters\Options\FormatterOptions;
  *
  * It is presumed that every row contains the same keys.
  */
-class RowsOfFields extends AbstractStructuredList
+class RowsOfFields extends AbstractStructuredList implements ConversionInterface
 {
+    /**
+     * @inheritdoc
+     */
+    public function convert(FormatterOptions $options)
+    {
+        $defaults = $this->defaultOptions();
+        $fields = $this->getFields($options, $defaults);
+        if (FieldProcessor::hasUnstructuredFieldAccess($fields)) {
+            return new UnstructuredListData($this->getArrayCopy());
+        }
+        return $this;
+    }
+
     /**
      * Restructure this data for output by converting it into a table
      * transformation object.

--- a/src/StructuredData/UnstructuredData.php
+++ b/src/StructuredData/UnstructuredData.php
@@ -3,7 +3,7 @@ namespace Consolidation\OutputFormatters\StructuredData;
 
 use Consolidation\OutputFormatters\Options\FormatterOptions;
 use Consolidation\OutputFormatters\StructuredData\RestructureInterface;
-use Consolidation\OutputFormatters\Transformations\UnstructuredDataListTransformation;
+use Consolidation\OutputFormatters\Transformations\UnstructuredDataTransformation;
 
 /**
  * Represents aribtrary unstructured array data where the
@@ -13,7 +13,7 @@ use Consolidation\OutputFormatters\Transformations\UnstructuredDataListTransform
  * RowsOfFields, which expects uniform rows), and the data elements may
  * themselves be deep arrays.
  */
-class UnstructuredListData extends AbstractListData implements RestructureInterface
+class UnstructuredData extends AbstractListData implements RestructureInterface
 {
     public function __construct($data)
     {
@@ -26,6 +26,6 @@ class UnstructuredListData extends AbstractListData implements RestructureInterf
         $defaults = $this->defaultOptions();
         $fields = $this->getFields($options, $defaults);
 
-        return new UnstructuredDataListTransformation($data, FieldProcessor::processFieldAliases($fields));
+        return new UnstructuredDataTransformation($data, FieldProcessor::processFieldAliases($fields));
     }
 }

--- a/src/StructuredData/UnstructuredData.php
+++ b/src/StructuredData/UnstructuredData.php
@@ -22,10 +22,9 @@ class UnstructuredData extends AbstractListData implements RestructureInterface
 
     public function restructure(FormatterOptions $options)
     {
-        $data = $this->getArrayCopy();
         $defaults = $this->defaultOptions();
         $fields = $this->getFields($options, $defaults);
 
-        return new UnstructuredDataTransformation($data, FieldProcessor::processFieldAliases($fields));
+        return new UnstructuredDataTransformation($this->getArrayCopy(), FieldProcessor::processFieldAliases($fields));
     }
 }

--- a/src/StructuredData/UnstructuredListData.php
+++ b/src/StructuredData/UnstructuredListData.php
@@ -22,10 +22,9 @@ class UnstructuredListData extends AbstractListData implements RestructureInterf
 
     public function restructure(FormatterOptions $options)
     {
-        $data = $this->getArrayCopy();
         $defaults = $this->defaultOptions();
         $fields = $this->getFields($options, $defaults);
 
-        return new UnstructuredDataListTransformation($data, FieldProcessor::processFieldAliases($fields));
+        return new UnstructuredDataListTransformation($this->getArrayCopy(), FieldProcessor::processFieldAliases($fields));
     }
 }

--- a/src/StructuredData/UnstructuredListData.php
+++ b/src/StructuredData/UnstructuredListData.php
@@ -1,0 +1,44 @@
+<?php
+namespace Consolidation\OutputFormatters\StructuredData;
+
+use Consolidation\OutputFormatters\Options\FormatterOptions;
+use Consolidation\OutputFormatters\StructuredData\RestructureInterface;
+use Consolidation\OutputFormatters\Transformations\UnstructuredDataTransformation;
+
+/**
+ * Represents aribtrary unstructured array data where the
+ * data to display in --list format comes from the array keys.
+ *
+ * Unstructured list data can have variable keys in every rown (unlike
+ * RowsOfFields, which expects uniform rows), and the data elements may
+ * themselves be deep arrays.
+ */
+class UnstructuredListData extends AbstractListData implements RestructureInterface
+{
+    public function __construct($data)
+    {
+        parent::__construct($data);
+    }
+
+    public function restructure(FormatterOptions $options)
+    {
+        $data = $this->getArrayCopy();
+        $defaults = $this->defaultOptions();
+        $fields = $this->getFields($options, $defaults);
+
+        return new UnstructuredDataTransformation($data, $this->processFieldAliases($fields));
+    }
+
+    protected function processFieldAliases($fields)
+    {
+        if (!is_array($fields)) {
+            $fields = array_filter(explode(',', $fields));
+        }
+        $transformed_fields = [];
+        foreach ($fields as $field) {
+            list($machine_name,$label) = explode(' as ', $field) + [$field, preg_replace('#.*\.#', '', $field)];
+            $transformed_fields[$machine_name] = $label;
+        }
+        return $transformed_fields;
+    }
+}

--- a/src/Transformations/ReorderFields.php
+++ b/src/Transformations/ReorderFields.php
@@ -57,6 +57,9 @@ class ReorderFields
 
     protected function getSelectedFieldKeys($fields, $fieldLabels)
     {
+        if (empty($fieldLabels)) {
+            return [];
+        }
         if (is_string($fields)) {
             $fields = explode(',', $fields);
         }

--- a/src/Transformations/SimplifyToStringInterface.php
+++ b/src/Transformations/SimplifyToStringInterface.php
@@ -1,0 +1,13 @@
+<?php
+namespace Consolidation\OutputFormatters\Transformations;
+
+use Consolidation\OutputFormatters\Options\FormatterOptions;
+
+interface SimplifyToStringInterface
+{
+    /**
+     * simplifyToString is called by the string formatter to convert
+     * structured data to a simple string.
+     */
+    public function simplifyToString(FormatterOptions $options);
+}

--- a/src/Transformations/StringTransformationInterface.php
+++ b/src/Transformations/StringTransformationInterface.php
@@ -3,7 +3,7 @@ namespace Consolidation\OutputFormatters\Transformations;
 
 use Consolidation\OutputFormatters\Options\FormatterOptions;
 
-interface SimplifyToStringInterface
+interface StringTransformationInterface
 {
     /**
      * simplifyToString is called by the string formatter to convert

--- a/src/Transformations/TableTransformation.php
+++ b/src/Transformations/TableTransformation.php
@@ -8,7 +8,7 @@ use Consolidation\OutputFormatters\Options\FormatterOptions;
 use Consolidation\OutputFormatters\Formatters\TsvFormatter;
 use Symfony\Component\Console\Output\BufferedOutput;
 
-class TableTransformation extends \ArrayObject implements TableDataInterface, SimplifyToStringInterface, OriginalDataInterface
+class TableTransformation extends \ArrayObject implements TableDataInterface, StringTransformationInterface, OriginalDataInterface
 {
     protected $headers;
     protected $rowLabels;

--- a/src/Transformations/TableTransformation.php
+++ b/src/Transformations/TableTransformation.php
@@ -4,8 +4,11 @@ namespace Consolidation\OutputFormatters\Transformations;
 use Consolidation\OutputFormatters\StructuredData\TableDataInterface;
 use Consolidation\OutputFormatters\StructuredData\OriginalDataInterface;
 use Consolidation\OutputFormatters\StructuredData\MetadataHolderInterface;
+use Consolidation\OutputFormatters\Options\FormatterOptions;
+use Consolidation\OutputFormatters\Formatters\TsvFormatter;
+use Symfony\Component\Console\Output\BufferedOutput;
 
-class TableTransformation extends \ArrayObject implements TableDataInterface, OriginalDataInterface
+class TableTransformation extends \ArrayObject implements TableDataInterface, SimplifyToStringInterface, OriginalDataInterface
 {
     protected $headers;
     protected $rowLabels;
@@ -38,6 +41,22 @@ class TableTransformation extends \ArrayObject implements TableDataInterface, Or
     public function isList()
     {
         return $this->layout == self::LIST_LAYOUT;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function simplifyToString(FormatterOptions $options)
+    {
+        $alternateFormatter = new TsvFormatter();
+        $output = new BufferedOutput();
+
+        try {
+            $data = $alternateFormatter->validate($this->getArrayCopy());
+            $alternateFormatter->write($output, $this->getArrayCopy(), $options);
+        } catch (\Exception $e) {
+        }
+        return $output->fetch();
     }
 
     protected static function transformRows($data, $fieldLabels)

--- a/src/Transformations/UnstructuredDataFieldAccessor.php
+++ b/src/Transformations/UnstructuredDataFieldAccessor.php
@@ -1,0 +1,36 @@
+<?php
+namespace Consolidation\OutputFormatters\Transformations;
+
+use Dflydev\DotAccessData\Data;
+
+class UnstructuredDataFieldAccessor
+{
+    protected $data;
+
+    public function __construct($data)
+    {
+        $this->data = $data;
+    }
+
+    public function get($fields)
+    {
+        $data = new Data($this->data);
+        $result = new Data();
+        foreach ($fields as $key => $label) {
+            $item = $data->get($key);
+            if (isset($item)) {
+                if ($label == '.') {
+                    if (!is_array($item)) {
+                        return $item;
+                    }
+                    foreach ($item as $key => $value) {
+                        $result->set($key, $value);
+                    }
+                } else {
+                    $result->set($label, $data->get($key));
+                }
+            }
+        }
+        return $result->export();
+    }
+}

--- a/src/Transformations/UnstructuredDataListTransformation.php
+++ b/src/Transformations/UnstructuredDataListTransformation.php
@@ -1,0 +1,38 @@
+<?php
+namespace Consolidation\OutputFormatters\Transformations;
+
+use Consolidation\OutputFormatters\Options\FormatterOptions;
+
+class UnstructuredDataListTransformation extends \ArrayObject implements StringTransformationInterface
+{
+    public function __construct($data, $fields)
+    {
+        $this->originalData = $data;
+        $rows = static::transformRows($data, $fields);
+        parent::__construct($rows);
+    }
+
+    protected static function transformRows($data, $fields)
+    {
+        $rows = [];
+        foreach ($data as $rowid => $row) {
+            $rows[$rowid] = UnstructuredDataTransformation::transformRow($row, $fields);
+        }
+        return $rows;
+    }
+
+    public function simplifyToString(FormatterOptions $options)
+    {
+        $result = '';
+        $iterator = $this->getIterator();
+        while ($iterator->valid()) {
+            $simplifiedRow = UnstructuredDataTransformation::simplifyRow($iterator->current());
+            if (isset($simplifiedRow)) {
+                $result .= "$simplifiedRow\n";
+            }
+
+            $iterator->next();
+        }
+        return $result;
+    }
+}

--- a/src/Transformations/UnstructuredDataTransformation.php
+++ b/src/Transformations/UnstructuredDataTransformation.php
@@ -1,0 +1,89 @@
+<?php
+namespace Consolidation\OutputFormatters\Transformations;
+
+use Dflydev\DotAccessData\Data;
+use Consolidation\OutputFormatters\Options\FormatterOptions;
+
+class UnstructuredDataTransformation extends \ArrayObject implements SimplifyToStringInterface
+{
+    protected $originalData;
+
+    public function __construct($data, $fields)
+    {
+        $this->originalData = $data;
+        $rows = static::transformRows($data, $fields);
+        parent::__construct($rows);
+    }
+
+    protected static function transformRows($data, $fields)
+    {
+        $rows = [];
+        foreach ($data as $rowid => $row) {
+            $rows[$rowid] = static::transformRow($row, $fields);
+        }
+        return $rows;
+    }
+
+    protected static function transformRow($row, $fields)
+    {
+        if (empty($fields)) {
+            return $row;
+        }
+        $data = new Data($row);
+        $result = new Data();
+        foreach ($fields as $key => $label) {
+            $item = $data->get($key);
+            if (isset($item)) {
+                if ($label == '.') {
+                    if (!is_array($item)) {
+                        return $item;
+                    }
+                    foreach ($item as $key => $value) {
+                        $result->set($key, $value);
+                    }
+                }
+                else {
+                    $result->set($label, $data->get($key));
+                }
+            }
+        }
+        return $result->export();
+    }
+
+    public function simplifyToString(FormatterOptions $options)
+    {
+        $result = '';
+        $iterator = $this->getIterator();
+        while($iterator->valid()) {
+            $simplifiedRow = $this->simplifyRow($iterator->current());
+            if (isset($simplifiedRow)) {
+                $result .= "$simplifiedRow\n";
+            }
+
+            $iterator->next();
+        }
+        return $result;
+    }
+
+    protected function simplifyRow($row)
+    {
+        if (is_string($row)) {
+            return $row;
+        }
+        if ($this->isSimpleArray($row)) {
+            return implode("\n", $row);
+        }
+        // No good way to simplify - just dump a json fragment
+        return json_encode($row);
+    }
+
+    protected function isSimpleArray($row)
+    {
+        foreach ($row as $item) {
+            if (!is_string($item)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/Transformations/UnstructuredDataTransformation.php
+++ b/src/Transformations/UnstructuredDataTransformation.php
@@ -41,8 +41,7 @@ class UnstructuredDataTransformation extends \ArrayObject implements SimplifyToS
                     foreach ($item as $key => $value) {
                         $result->set($key, $value);
                     }
-                }
-                else {
+                } else {
                     $result->set($label, $data->get($key));
                 }
             }
@@ -54,7 +53,7 @@ class UnstructuredDataTransformation extends \ArrayObject implements SimplifyToS
     {
         $result = '';
         $iterator = $this->getIterator();
-        while($iterator->valid()) {
+        while ($iterator->valid()) {
             $simplifiedRow = $this->simplifyRow($iterator->current());
             if (isset($simplifiedRow)) {
                 $result .= "$simplifiedRow\n";

--- a/src/Transformations/UnstructuredDataTransformation.php
+++ b/src/Transformations/UnstructuredDataTransformation.php
@@ -1,82 +1,46 @@
 <?php
 namespace Consolidation\OutputFormatters\Transformations;
 
-use Dflydev\DotAccessData\Data;
 use Consolidation\OutputFormatters\Options\FormatterOptions;
 
-class UnstructuredDataTransformation extends \ArrayObject implements SimplifyToStringInterface
+class UnstructuredDataTransformation extends \ArrayObject implements StringTransformationInterface
 {
     protected $originalData;
 
     public function __construct($data, $fields)
     {
         $this->originalData = $data;
-        $rows = static::transformRows($data, $fields);
+        $rows = static::transformRow($data, $fields);
         parent::__construct($rows);
-    }
-
-    protected static function transformRows($data, $fields)
-    {
-        $rows = [];
-        foreach ($data as $rowid => $row) {
-            $rows[$rowid] = static::transformRow($row, $fields);
-        }
-        return $rows;
-    }
-
-    protected static function transformRow($row, $fields)
-    {
-        if (empty($fields)) {
-            return $row;
-        }
-        $data = new Data($row);
-        $result = new Data();
-        foreach ($fields as $key => $label) {
-            $item = $data->get($key);
-            if (isset($item)) {
-                if ($label == '.') {
-                    if (!is_array($item)) {
-                        return $item;
-                    }
-                    foreach ($item as $key => $value) {
-                        $result->set($key, $value);
-                    }
-                } else {
-                    $result->set($label, $data->get($key));
-                }
-            }
-        }
-        return $result->export();
     }
 
     public function simplifyToString(FormatterOptions $options)
     {
-        $result = '';
-        $iterator = $this->getIterator();
-        while ($iterator->valid()) {
-            $simplifiedRow = $this->simplifyRow($iterator->current());
-            if (isset($simplifiedRow)) {
-                $result .= "$simplifiedRow\n";
-            }
-
-            $iterator->next();
-        }
-        return $result;
+        return static::simplifyRow($this->getArrayCopy());
     }
 
-    protected function simplifyRow($row)
+    public static function transformRow($row, $fields)
+    {
+        if (empty($fields)) {
+            return $row;
+        }
+        $fieldAccessor = new UnstructuredDataFieldAccessor($row);
+        return $fieldAccessor->get($fields);
+    }
+
+    public static function simplifyRow($row)
     {
         if (is_string($row)) {
             return $row;
         }
-        if ($this->isSimpleArray($row)) {
+        if (static::isSimpleArray($row)) {
             return implode("\n", $row);
         }
         // No good way to simplify - just dump a json fragment
         return json_encode($row);
     }
 
-    protected function isSimpleArray($row)
+    protected static function isSimpleArray($row)
     {
         foreach ($row as $item) {
             if (!is_string($item)) {

--- a/tests/testFormatters.php
+++ b/tests/testFormatters.php
@@ -1063,6 +1063,21 @@ metadata:
 EOT;
         $this->assertFormattedOutputMatches($expected, 'yaml', $rowsOfFieldsWithMetadata, new FormatterOptions(['fields' => ['three', 'one']]));
 
+        // TODO: Is metadata handling correct with field remapping? Should metadata be preserved, or removed entirely?
+        $expected = <<<EOT
+metadata: {  }
+id-123:
+  iii: c
+  i: a
+id-456:
+  iii: z
+  i: x
+EOT;
+
+
+        $this->assertFormattedOutputMatches($expected, 'yaml', $rowsOfFieldsWithMetadata, new FormatterOptions(['fields' => ['three as iii', 'one as i']]));
+
+
     }
 
     function assertDataAndMetadata($rowsOfFieldsWithMetadata, $data, $metadata)

--- a/tests/testFormatters.php
+++ b/tests/testFormatters.php
@@ -9,6 +9,8 @@ use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 use Consolidation\OutputFormatters\StructuredData\RowsOfFieldsWithMetadata;
 use Consolidation\OutputFormatters\StructuredData\PropertyList;
 use Consolidation\OutputFormatters\StructuredData\ListDataFromKeys;
+use Consolidation\OutputFormatters\StructuredData\UnstructuredListData;
+use Consolidation\OutputFormatters\StructuredData\UnstructuredData;
 use Consolidation\OutputFormatters\StructuredData\NumericCellRenderer;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -61,14 +63,24 @@ c
 EOT;
         $this->assertFormattedOutputMatches($expected, 'list', $data);
 
-        $data = new ListDataFromKeys($data);
+        // @deprecated: replaced by UnstructuredListData
+        $listData = new ListDataFromKeys($data);
 
         $expected = <<<EOT
 one: a
 two: b
 three: c
 EOT;
-        $this->assertFormattedOutputMatches($expected, 'yaml', $data);
+        $this->assertFormattedOutputMatches($expected, 'yaml', $listData);
+
+        $unstructuredData = new UnstructuredData($data);
+
+        $expected = <<<EOT
+one: a
+two: b
+three: c
+EOT;
+        $this->assertFormattedOutputMatches($expected, 'yaml', $unstructuredData);
 
         $expected = <<<EOT
 one
@@ -76,7 +88,16 @@ two
 three
 EOT;
 
-        $this->assertFormattedOutputMatches($expected, 'list', $data);
+        $this->assertFormattedOutputMatches($expected, 'list', $unstructuredData);
+
+        $options = new FormatterOptions([FormatterOptions::FIELDS => 'one as I,two as II,three as III']);
+        $expected = <<<EOT
+I: a
+II: b
+III: c
+EOT;
+        $this->assertFormattedOutputMatches($expected, 'yaml', $unstructuredData, $options);
+
     }
 
     function testNestedYaml()
@@ -112,7 +133,60 @@ three:
 EOT;
 
         $this->assertFormattedOutputMatches($expected, 'yaml', $data);
+
+        $options = new FormatterOptions([FormatterOptions::FIELDS => 'i as A,ii as B,iii as C']);
+        $expected = <<<EOT
+one:
+  A:
+    - a
+    - b
+    - c
+two:
+  B:
+    - q
+    - r
+    - s
+three:
+  C:
+    - t
+    - u
+    - v
+EOT;
+
+        $unstructuredData = new UnstructuredListData($data);
+        $this->assertFormattedOutputMatches($expected, 'yaml', $unstructuredData, $options);
     }
+
+    function testDeepUnstructuredYaml()
+    {
+        $data = [
+            'root' => [
+                'one' => [
+                    'i' => ['a' => 'ape', 'b' => 'bat', 'c' => 'cat'],
+                ],
+                'two' => [
+                    'ii' => ['q' => 'quail', 'r' => 'rabbit', 's' => 'snake'],
+                ],
+                'three' => [
+                    'iii' => ['t' => 'turtle', 'u' => 'unicorn', 'v' => 'vulture'],
+                ],
+            ],
+        ];
+
+        $expected = <<<EOT
+root:
+  cool: cat
+  unique: unicorn
+  slithering: snake
+EOT;
+
+        $options = new FormatterOptions([FormatterOptions::FIELDS => 'one.i.c as cool,three.iii.u as unique,two.ii.s as slithering']);
+
+        $unstructuredData = new UnstructuredListData($data);
+        $this->assertFormattedOutputMatches($expected, 'yaml', $unstructuredData, $options);
+    }
+
+
 
     function testSimpleJson()
     {


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes

### Summary
Using --fields and --field options, this PR allows individual data items to be selected and extracted from unstructured data.

### Examples
```
$ ./drush sa @wk
'@wk.dev':
  uri: 'http://dev.westkingdom.org'
  root: /Users/ga/local/sca/website
'@wk.live':
  host: example.com
  uri: 'http://westkingdom.org'
  user: www-admin
  root: /var/www/westkingdom/drupal
  paths:
    alias-paths:
      - sites/drush
$ ./drush sa @wk --fields=host,uri
'@wk.dev':
  uri: 'http://dev.westkingdom.org'
'@wk.live':
  host: example.com
  uri: 'http://westkingdom.org'
$ ./drush sa @wk --fields='host as h,uri as u'
'@wk.dev':
  u: 'http://dev.westkingdom.org'
'@wk.live':
  h: example.com
  u: 'http://westkingdom.org'
$ ./drush sa @wk --fields='paths.alias-paths'
'@wk.dev': {  }
'@wk.live':
  alias-paths:
    - sites/drush
$ ./drush sa @wk --fields='paths.alias-paths as .' 
'@wk.dev': {  }
'@wk.live':
  - sites/drush
$ ./drush sa @wk --fields='root' 
'@wk.dev':
  root: /Users/ga/local/sca/website
'@wk.live':
  root: /var/www/westkingdom/drupal
$ ./drush sa @wk --fields='root as .' 
'@wk.dev': /Users/ga/local/sca/website
'@wk.live': /var/www/westkingdom/drupal
```
