### PR TITLE
Add a 'null' format that produces no output.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,7 +55,7 @@ install:
   - mkdir c:\test_temp
 
 test_script:
-  - php composer.phar unit
+  - php composer.phar unit -- --testsuite formatters
 
 # environment variables
 environment:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,7 +55,7 @@ install:
   - mkdir c:\test_temp
 
 test_script:
-  - php vendor/bin/phpunit
+  - php composer.phar unit -- --configuration phpunit.xml.dist
 
 # environment variables
 environment:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,7 +55,7 @@ install:
   - mkdir c:\test_temp
 
 test_script:
-  - php composer.phar unit -- --testsuite formatters
+  - php vendor/bin/phpunit
 
 # environment variables
 environment:

--- a/docs/api.md
+++ b/docs/api.md
@@ -18,6 +18,7 @@
 - [\Consolidation\OutputFormatters\Formatters\StringFormatter](#class-consolidationoutputformattersformattersstringformatter)
 - [\Consolidation\OutputFormatters\Formatters\VarExportFormatter](#class-consolidationoutputformattersformattersvarexportformatter)
 - [\Consolidation\OutputFormatters\Formatters\YamlFormatter](#class-consolidationoutputformattersformattersyamlformatter)
+- [\Consolidation\OutputFormatters\Formatters\NoOutputFormatter](#class-consolidationoutputformattersformattersnooutputformatter)
 - [\Consolidation\OutputFormatters\Formatters\TableFormatter](#class-consolidationoutputformattersformatterstableformatter)
 - [\Consolidation\OutputFormatters\Formatters\XmlFormatter](#class-consolidationoutputformattersformattersxmlformatter)
 - [\Consolidation\OutputFormatters\Formatters\PrintRFormatter](#class-consolidationoutputformattersformattersprintrformatter)
@@ -324,6 +325,20 @@
 | public | <strong>write(</strong><em>\Symfony\Component\Console\Output\OutputInterface</em> <strong>$output</strong>, <em>mixed</em> <strong>$data</strong>, <em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>void</em><br /><em>Given structured data, apply appropriate formatting, and return a printable string.</em> |
 
 *This class implements [\Consolidation\OutputFormatters\Formatters\FormatterInterface](#interface-consolidationoutputformattersformattersformatterinterface)*
+
+<hr />
+
+### Class: \Consolidation\OutputFormatters\Formatters\NoOutputFormatter
+
+> No output formatter This formatter never produces any output. It is useful in cases where a command should not produce any output by default, but may do so if the user explicitly includes a --format option.
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>isValidDataType(</strong><em>[\ReflectionClass](http://php.net/manual/en/class.reflectionclass.php)</em> <strong>$dataType</strong>)</strong> : <em>bool</em><br /><em>All data types are acceptable.</em> |
+| public | <strong>validate(</strong><em>mixed</em> <strong>$structuredData</strong>)</strong> : <em>mixed</em><br /><em>Throw an IncompatibleDataException if the provided data cannot be processed by this formatter.  Return the source data if it is valid. The data may be encapsulated or converted if necessary.</em> |
+| public | <strong>write(</strong><em>\Symfony\Component\Console\Output\OutputInterface</em> <strong>$output</strong>, <em>mixed</em> <strong>$data</strong>, <em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>void</em><br /><em>Given structured data, apply appropriate formatting, and return a printable string.</em> |
+
+*This class implements [\Consolidation\OutputFormatters\Formatters\FormatterInterface](#interface-consolidationoutputformattersformattersformatterinterface), [\Consolidation\OutputFormatters\Validate\ValidationInterface](#interface-consolidationoutputformattersvalidatevalidationinterface)*
 
 <hr />
 

--- a/src/FormatterManager.php
+++ b/src/FormatterManager.php
@@ -39,6 +39,7 @@ class FormatterManager
     public function addDefaultFormatters()
     {
         $defaultFormatters = [
+            'null' => '\Consolidation\OutputFormatters\Formatters\NoOutputFormatter',
             'string' => '\Consolidation\OutputFormatters\Formatters\StringFormatter',
             'yaml' => '\Consolidation\OutputFormatters\Formatters\YamlFormatter',
             'xml' => '\Consolidation\OutputFormatters\Formatters\XmlFormatter',

--- a/src/Formatters/NoOutputFormatter.php
+++ b/src/Formatters/NoOutputFormatter.php
@@ -1,0 +1,40 @@
+<?php
+namespace Consolidation\OutputFormatters\Formatters;
+
+use Consolidation\OutputFormatters\Validate\ValidationInterface;
+use Consolidation\OutputFormatters\Options\FormatterOptions;
+use Consolidation\OutputFormatters\Validate\ValidDataTypesTrait;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * No output formatter
+ *
+ * This formatter never produces any output. It is useful in cases where
+ * a command should not produce any output by default, but may do so if
+ * the user explicitly includes a --format option.
+ */
+class NoOutputFormatter implements FormatterInterface, ValidationInterface
+{
+    /**
+     * All data types are acceptable.
+     */
+    public function isValidDataType(\ReflectionClass $dataType)
+    {
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function validate($structuredData)
+    {
+        return $structuredData;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function write(OutputInterface $output, $data, FormatterOptions $options)
+    {
+    }
+}

--- a/tests/testFormatters.php
+++ b/tests/testFormatters.php
@@ -98,6 +98,8 @@ III: c
 EOT;
         $this->assertFormattedOutputMatches($expected, 'yaml', $unstructuredData, $options);
 
+        // Ensure that the 'null' format produces no output at all
+        $this->assertFormattedOutputMatches('', 'null', $unstructuredData);
     }
 
     function testNestedYaml()
@@ -950,7 +952,7 @@ EOT;
     /**
      * @expectedException \Consolidation\OutputFormatters\Exception\InvalidFormatException
      * @expectedExceptionCode 1
-     * @expectedExceptionMessage The format table cannot be used with the data produced by this command, which was an array.  Valid formats are: csv,json,list,php,print-r,string,tsv,var_dump,var_export,xml,yaml
+     * @expectedExceptionMessage The format table cannot be used with the data produced by this command, which was an array.  Valid formats are: csv,json,list,null,php,print-r,string,tsv,var_dump,var_export,xml,yaml
      */
     function testIncompatibleDataForTableFormatter()
     {
@@ -961,7 +963,7 @@ EOT;
     /**
      * @expectedException \Consolidation\OutputFormatters\Exception\InvalidFormatException
      * @expectedExceptionCode 1
-     * @expectedExceptionMessage The format sections cannot be used with the data produced by this command, which was an array.  Valid formats are: csv,json,list,php,print-r,string,tsv,var_dump,var_export,xml,yaml
+     * @expectedExceptionMessage The format sections cannot be used with the data produced by this command, which was an array.  Valid formats are: csv,json,list,null,php,print-r,string,tsv,var_dump,var_export,xml,yaml
      */
     function testIncompatibleDataForSectionsFormatter()
     {
@@ -1416,7 +1418,7 @@ EOT;
     /**
      * @expectedException \Consolidation\OutputFormatters\Exception\InvalidFormatException
      * @expectedExceptionCode 1
-     * @expectedExceptionMessage The format table cannot be used with the data produced by this command, which was an array.  Valid formats are: csv,json,list,php,print-r,string,tsv,var_dump,var_export,xml,yaml
+     * @expectedExceptionMessage The format table cannot be used with the data produced by this command, which was an array.  Valid formats are: csv,json,list,null,php,print-r,string,tsv,var_dump,var_export,xml,yaml
      */
     function testIncompatibleListDataForTableFormatter()
     {

--- a/tests/testValidFormats.php
+++ b/tests/testValidFormats.php
@@ -51,19 +51,19 @@ class ValidFormatsTests extends TestCase
 
         // Check to see which formats can handle a simple array
         $validFormats = $this->formatterManager->validFormats([]);
-        $this->assertEquals('csv,json,list,php,print-r,string,tsv,var_dump,var_export,xml,yaml', implode(',', $validFormats));
+        $this->assertEquals('csv,json,list,null,php,print-r,string,tsv,var_dump,var_export,xml,yaml', implode(',', $validFormats));
 
         // Check to see which formats can handle an PropertyList
         $validFormats = $this->formatterManager->validFormats($associativeListRef);
-        $this->assertEquals('csv,json,list,php,print-r,string,table,tsv,var_dump,var_export,xml,yaml', implode(',', $validFormats));
+        $this->assertEquals('csv,json,list,null,php,print-r,string,table,tsv,var_dump,var_export,xml,yaml', implode(',', $validFormats));
 
         // Check to see which formats can handle an RowsOfFields
         $validFormats = $this->formatterManager->validFormats($rowsOfFieldsRef);
-        $this->assertEquals('csv,json,list,php,print-r,sections,string,table,tsv,var_dump,var_export,xml,yaml', implode(',', $validFormats));
+        $this->assertEquals('csv,json,list,null,php,print-r,sections,string,table,tsv,var_dump,var_export,xml,yaml', implode(',', $validFormats));
 
         // TODO: it woud be better if this returned an empty set instead of 'string'.
         $validFormats = $this->formatterManager->validFormats($notADataType);
-        $this->assertEquals('string', implode(',', $validFormats));
+        $this->assertEquals('null,string', implode(',', $validFormats));
     }
 
     function testAutomaticOptions()
@@ -75,7 +75,7 @@ class ValidFormatsTests extends TestCase
             ]
         );
         $inputOptions = $this->formatterManager->automaticOptions($formatterOptions, $rowsOfFieldsRef);
-        $this->assertInputOptionDescriptionsEquals("Format the result data. Available formats: csv,json,list,php,print-r,sections,string,table,tsv,var_dump,var_export,xml,yaml [Default: 'table']\nAvailable fields: Name (name), Phone Number (phone_number) [Default: '']\nSelect just one field, and force format to 'string'. [Default: '']", $inputOptions);
+        $this->assertInputOptionDescriptionsEquals("Format the result data. Available formats: csv,json,list,null,php,print-r,sections,string,table,tsv,var_dump,var_export,xml,yaml [Default: 'table']\nAvailable fields: Name (name), Phone Number (phone_number) [Default: '']\nSelect just one field, and force format to 'string'. [Default: '']", $inputOptions);
     }
 
     function assertInputOptionDescriptionsEquals($expected, $inputOptions)


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes

### Summary
Add an output format that accepts all data types but never produces output.