### PR TITLE
Fixes #76: Do not print a newline after output.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -18,6 +18,7 @@
 - [\Consolidation\OutputFormatters\Formatters\StringFormatter](#class-consolidationoutputformattersformattersstringformatter)
 - [\Consolidation\OutputFormatters\Formatters\VarExportFormatter](#class-consolidationoutputformattersformattersvarexportformatter)
 - [\Consolidation\OutputFormatters\Formatters\YamlFormatter](#class-consolidationoutputformattersformattersyamlformatter)
+- [\Consolidation\OutputFormatters\Formatters\ImplicitEolInterface (interface)](#interface-consolidationoutputformattersformattersimpliciteolinterface)
 - [\Consolidation\OutputFormatters\Formatters\NoOutputFormatter](#class-consolidationoutputformattersformattersnooutputformatter)
 - [\Consolidation\OutputFormatters\Formatters\TableFormatter](#class-consolidationoutputformattersformatterstableformatter)
 - [\Consolidation\OutputFormatters\Formatters\XmlFormatter](#class-consolidationoutputformattersformattersxmlformatter)
@@ -329,6 +330,15 @@
 
 <hr />
 
+### Interface: \Consolidation\OutputFormatters\Formatters\ImplicitEolInterface
+
+> This is a marker interface that should be implemented by all formatters that always print an end-of-line character at the end of their input.
+
+| Visibility | Function |
+|:-----------|:---------|
+
+<hr />
+
 ### Class: \Consolidation\OutputFormatters\Formatters\NoOutputFormatter
 
 > No output formatter This formatter never produces any output. It is useful in cases where a command should not produce any output by default, but may do so if the user explicitly includes a --format option.
@@ -448,8 +458,10 @@
 | public | <strong>getInputOptions(</strong><em>array</em> <strong>$defaults</strong>)</strong> : <em>array</em><br /><em>Return all of the options from the provided $defaults array that exist in our InputInterface object.</em> |
 | public | <strong>getOptions()</strong> : <em>array</em><br /><em>Return a reference to the user-specified options for this request.</em> |
 | public | <strong>getXmlSchema()</strong> : <em>[\Consolidation\OutputFormatters\StructuredData\Xml\XmlSchema](#class-consolidationoutputformattersstructureddataxmlxmlschema)</em><br /><em>Return the XmlSchema to use with --format=xml for data types that support that.  This is used when an array needs to be converted into xml.</em> |
+| public | <strong>isInteractive()</strong> : <em>bool</em><br /><em>Check to see if we are in interactive mode. If we were never given a reference to the input object, then assume not.</em> |
 | public | <strong>override(</strong><em>array</em> <strong>$configurationData</strong>)</strong> : <em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em><br /><em>Create a new FormatterOptions object with new configuration data (provided), and the same options data as this instance.</em> |
 | public | <strong>parsePropertyList(</strong><em>string</em> <strong>$value</strong>)</strong> : <em>array</em><br /><em>Convert from a textual list to an array</em> |
+| public | <strong>removeOption(</strong><em>mixed</em> <strong>$key</strong>)</strong> : <em>void</em><br /><em>Remove an option.</em> |
 | public | <strong>setConfigurationData(</strong><em>array</em> <strong>$configurationData</strong>)</strong> : <em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em><br /><em>Change the configuration data for this formatter options object.</em> |
 | public | <strong>setConfigurationDefault(</strong><em>string</em> <strong>$key</strong>, <em>mixed</em> <strong>$value</strong>)</strong> : <em>\Consolidation\OutputFormatters\Options\FormetterOptions</em><br /><em>Change one configuration value for this formatter option, but only if it does not already have a value set.</em> |
 | public | <strong>setDefaultFields(</strong><em>mixed</em> <strong>$fields</strong>)</strong> : <em>void</em> |
@@ -465,6 +477,8 @@
 | public | <strong>setRowLabels(</strong><em>mixed</em> <strong>$rowLabels</strong>)</strong> : <em>void</em> |
 | public | <strong>setTableStyle(</strong><em>mixed</em> <strong>$style</strong>)</strong> : <em>void</em> |
 | public | <strong>setWidth(</strong><em>mixed</em> <strong>$width</strong>)</strong> : <em>void</em> |
+| public | <strong>shouldAppendNewline(</strong><em>\Symfony\Component\Console\Output\OutputInterface</em> <strong>$output</strong>)</strong> : <em>bool</em> |
+| protected | <strong>defaultAppendEol(</strong><em>\Symfony\Component\Console\Output\OutputInterface</em> <strong>$output</strong>)</strong> : <em>void</em> |
 | protected | <strong>defaultsForKey(</strong><em>string</em> <strong>$key</strong>, <em>array</em> <strong>$defaults</strong>, <em>bool</em> <strong>$default=false</strong>)</strong> : <em>array</em><br /><em>Reduce provided defaults to the single item identified by '$key', if it exists, or an empty array otherwise.</em> |
 | protected | <strong>fetch(</strong><em>string</em> <strong>$key</strong>, <em>array</em> <strong>$defaults=array()</strong>, <em>bool/mixed</em> <strong>$default=false</strong>)</strong> : <em>mixed</em><br /><em>Look up a key, and return its raw value.</em> |
 | protected | <strong>fetchRawValues(</strong><em>array</em> <strong>$defaults=array()</strong>)</strong> : <em>array</em><br /><em>Look up all of the items associated with the provided defaults.</em> |

--- a/src/FormatterManager.php
+++ b/src/FormatterManager.php
@@ -21,6 +21,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Consolidation\OutputFormatters\StructuredData\OriginalDataInterface;
 use Consolidation\OutputFormatters\StructuredData\ListDataFromKeys;
 use Consolidation\OutputFormatters\StructuredData\ConversionInterface;
+use Consolidation\OutputFormatters\Formatters\ImplicitEolInterface;
 
 /**
  * Manage a collection of formatters; return one on request.
@@ -238,6 +239,11 @@ class FormatterManager
             $formatter->writeMetadata($output, $structuredOutput, $options);
         }
         $formatter->write($output, $restructuredOutput, $options);
+        // In interactive mode, write an extra newline after the output,
+        // but only if the formatter has not already implicitly done so.
+        if ($options->shouldAppendNewline($output) && !$formatter instanceof ImplicitEolInterface) {
+            $output->writeln();
+        }
     }
 
     protected function validateAndRestructure(FormatterInterface $formatter, $structuredOutput, FormatterOptions $options)

--- a/src/Formatters/ImplicitEolInterface.php
+++ b/src/Formatters/ImplicitEolInterface.php
@@ -1,0 +1,11 @@
+<?php
+namespace Consolidation\OutputFormatters\Formatters;
+
+/**
+ * This is a marker interface that should be implemented by
+ * all formatters that always print an end-of-line character
+ * at the end of their input.
+ */
+interface ImplicitEolInterface
+{
+}

--- a/src/Formatters/JsonFormatter.php
+++ b/src/Formatters/JsonFormatter.php
@@ -16,6 +16,6 @@ class JsonFormatter implements FormatterInterface
      */
     public function write(OutputInterface $output, $data, FormatterOptions $options)
     {
-        $output->writeln(json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        $output->write(json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
     }
 }

--- a/src/Formatters/ListFormatter.php
+++ b/src/Formatters/ListFormatter.php
@@ -22,7 +22,7 @@ class ListFormatter implements FormatterInterface, OverrideRestructureInterface,
      */
     public function write(OutputInterface $output, $data, FormatterOptions $options)
     {
-        $output->writeln(implode("\n", $data));
+        $output->write(implode("\n", $data));
     }
 
     /**

--- a/src/Formatters/PrintRFormatter.php
+++ b/src/Formatters/PrintRFormatter.php
@@ -16,6 +16,6 @@ class PrintRFormatter implements FormatterInterface
      */
     public function write(OutputInterface $output, $data, FormatterOptions $options)
     {
-        $output->writeln(print_r($data, true));
+        $output->write(print_r($data, true));
     }
 }

--- a/src/Formatters/SerializeFormatter.php
+++ b/src/Formatters/SerializeFormatter.php
@@ -16,6 +16,6 @@ class SerializeFormatter implements FormatterInterface
      */
     public function write(OutputInterface $output, $data, FormatterOptions $options)
     {
-        $output->writeln(serialize($data));
+        $output->write(serialize($data));
     }
 }

--- a/src/Formatters/StringFormatter.php
+++ b/src/Formatters/StringFormatter.php
@@ -41,7 +41,7 @@ class StringFormatter implements FormatterInterface, ValidationInterface, Overri
     public function write(OutputInterface $output, $data, FormatterOptions $options)
     {
         if (is_string($data)) {
-            return $output->writeln($data);
+            return $output->write($data);
         }
         return $this->reduceToSigleFieldAndWrite($output, $data, $options);
     }

--- a/src/Formatters/VarDumpFormatter.php
+++ b/src/Formatters/VarDumpFormatter.php
@@ -33,7 +33,7 @@ class VarDumpFormatter implements FormatterInterface
             // VarDumper v2.
             $stream = fopen('php://memory', 'r+b');
             $dumper->dump($cloned_data, $stream);
-            $output->writeln(stream_get_contents($stream, -1, 0));
+            $output->write(stream_get_contents($stream, -1, 0));
             fclose($stream);
         }
     }

--- a/src/Formatters/VarExportFormatter.php
+++ b/src/Formatters/VarExportFormatter.php
@@ -16,6 +16,6 @@ class VarExportFormatter implements FormatterInterface
      */
     public function write(OutputInterface $output, $data, FormatterOptions $options)
     {
-        $output->writeln(var_export($data, true));
+        $output->write(var_export($data, true));
     }
 }

--- a/src/Formatters/XmlFormatter.php
+++ b/src/Formatters/XmlFormatter.php
@@ -74,6 +74,6 @@ class XmlFormatter implements FormatterInterface, ValidDataTypesInterface
             $dom = $schema->arrayToXML($dom);
         }
         $dom->formatOutput = true;
-        $output->writeln($dom->saveXML());
+        $output->write($dom->saveXML());
     }
 }

--- a/src/Formatters/YamlFormatter.php
+++ b/src/Formatters/YamlFormatter.php
@@ -22,6 +22,6 @@ class YamlFormatter implements FormatterInterface
         $indent = 2;
         // The level where you switch to inline YAML is set to PHP_INT_MAX to
         // ensure this does not occur.
-        $output->writeln(Yaml::dump($data, PHP_INT_MAX, $indent, false, true));
+        $output->write(Yaml::dump($data, PHP_INT_MAX, $indent, false, true));
     }
 }


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [x] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Do not print a newline after input

### Description
It is inconvenient for scripts if formatters always   add an eol at the end of all output, as this extra character might sometimes be significant. Omitting this character relieves the caller from the need to trim the output.

Note that some formatters (typically the table formatters) still print an implicit newline. We take care not to print two newlines, though.

All of the existing tests pass, but the existing tests tend to trim the output before comparing, in order to be agnostic about whether a final newline appears or not. We should add additional tests to confirm that the eol is missing when it should be missing, and is present when it is expected to be.

Note that the caller may strongly stipulate whether of not the eol should always, never or sometimes be printed. If the answer is "sometimes", then it is printed when output is going to the console, and it is not  printed when output is being redirected. We could restore backwards compatibility here by initializiing this flag to `true` by default. If we did this, then clients that want the new behavior (e.g. drus) would have to clear this value in an appropriate hook.

We could also just bump the major version number of this library and let the b/c break remain.
