### PR TITLE
Fixes #78 - adds enclosure and escape character options for CsvFormatter.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -246,10 +246,10 @@
 | public | <strong>validDataTypes()</strong> : <em>void</em> |
 | public | <strong>validate(</strong><em>mixed</em> <strong>$structuredData</strong>)</strong> : <em>void</em> |
 | public | <strong>write(</strong><em>\Symfony\Component\Console\Output\OutputInterface</em> <strong>$output</strong>, <em>mixed</em> <strong>$data</strong>, <em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>void</em><br /><em>Given structured data, apply appropriate formatting, and return a printable string.</em> |
-| protected | <strong>csvEscape(</strong><em>mixed</em> <strong>$data</strong>, <em>string</em> <strong>$delimiter=`','`</strong>)</strong> : <em>void</em> |
+| protected | <strong>csvEscape(</strong><em>array</em> <strong>$data</strong>, <em>string</em> <strong>$delimiter=`','`</strong>, <em>string</em> <strong>$enclosure=`'"'`</strong>, <em>string</em> <strong>$escapeChar=`'\'`</strong>)</strong> : <em>string/bool the formatted CSV string, or FALSE if the formatting failed.</em><br /><em>Generates a CSV-escaped string from an array of field data.</em> |
 | protected | <strong>getDefaultFormatterOptions()</strong> : <em>array</em><br /><em>Return default values for formatter options</em> |
 | protected | <strong>renderEachCell(</strong><em>mixed</em> <strong>$originalData</strong>, <em>mixed</em> <strong>$restructuredData</strong>, <em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em> <strong>$options</strong>)</strong> : <em>void</em> |
-| protected | <strong>writeOneLine(</strong><em>\Symfony\Component\Console\Output\OutputInterface</em> <strong>$output</strong>, <em>mixed</em> <strong>$data</strong>, <em>mixed</em> <strong>$options</strong>)</strong> : <em>void</em> |
+| protected | <strong>writeOneLine(</strong><em>\Symfony\Component\Console\Output\OutputInterface</em> <strong>$output</strong>, <em>array</em> <strong>$data</strong>, <em>\Consolidation\OutputFormatters\Formatters\FormatterOptions</em> <strong>$options</strong>)</strong> : <em>void</em><br /><em>Writes a single a single line of formatted CSV data to the output stream.</em> |
 
 *This class implements [\Consolidation\OutputFormatters\Formatters\FormatterInterface](#interface-consolidationoutputformattersformattersformatterinterface), [\Consolidation\OutputFormatters\Validate\ValidDataTypesInterface](#interface-consolidationoutputformattersvalidatevaliddatatypesinterface), [\Consolidation\OutputFormatters\Validate\ValidationInterface](#interface-consolidationoutputformattersvalidatevalidationinterface), [\Consolidation\OutputFormatters\Formatters\RenderDataInterface](#interface-consolidationoutputformattersformattersrenderdatainterface)*
 
@@ -452,6 +452,8 @@
 | public | <strong>parsePropertyList(</strong><em>string</em> <strong>$value</strong>)</strong> : <em>array</em><br /><em>Convert from a textual list to an array</em> |
 | public | <strong>setConfigurationData(</strong><em>array</em> <strong>$configurationData</strong>)</strong> : <em>[\Consolidation\OutputFormatters\Options\FormatterOptions](#class-consolidationoutputformattersoptionsformatteroptions)</em><br /><em>Change the configuration data for this formatter options object.</em> |
 | public | <strong>setConfigurationDefault(</strong><em>string</em> <strong>$key</strong>, <em>mixed</em> <strong>$value</strong>)</strong> : <em>\Consolidation\OutputFormatters\Options\FormetterOptions</em><br /><em>Change one configuration value for this formatter option, but only if it does not already have a value set.</em> |
+| public | <strong>setCsvEnclosure(</strong><em>mixed</em> <strong>$enclosure</strong>)</strong> : <em>void</em> |
+| public | <strong>setCsvEscapeChar(</strong><em>mixed</em> <strong>$escapeChar</strong>)</strong> : <em>void</em> |
 | public | <strong>setDefaultFields(</strong><em>mixed</em> <strong>$fields</strong>)</strong> : <em>void</em> |
 | public | <strong>setDefaultStringField(</strong><em>mixed</em> <strong>$defaultStringField</strong>)</strong> : <em>void</em> |
 | public | <strong>setDelimiter(</strong><em>mixed</em> <strong>$delimiter</strong>)</strong> : <em>void</em> |

--- a/src/Formatters/CsvFormatter.php
+++ b/src/Formatters/CsvFormatter.php
@@ -66,6 +66,8 @@ class CsvFormatter implements FormatterInterface, ValidDataTypesInterface, Rende
         return [
             FormatterOptions::INCLUDE_FIELD_LABELS => true,
             FormatterOptions::DELIMITER => ',',
+            FormatterOptions::CSV_ENCLOSURE => '"',
+            FormatterOptions::CSV_ESCAPE_CHAR => "\\",
         ];
     }
 
@@ -87,18 +89,36 @@ class CsvFormatter implements FormatterInterface, ValidDataTypesInterface, Rende
         }
     }
 
+  /**
+   * Writes a single a single line of formatted CSV data to the output stream.
+   *
+   * @param OutputInterface $output the output stream to write to.
+   * @param array $data an array of field data to convert to a CSV string.
+   * @param FormatterOptions $options the specified options for this formatter.
+   */
     protected function writeOneLine(OutputInterface $output, $data, $options)
     {
         $defaults = $this->getDefaultFormatterOptions();
         $delimiter = $options->get(FormatterOptions::DELIMITER, $defaults);
-
-        $output->write($this->csvEscape($data, $delimiter));
+        $enclosure = $options->get(FormatterOptions::CSV_ENCLOSURE, $defaults);
+        $escapeChar = $options->get(FormatterOptions::CSV_ESCAPE_CHAR, $defaults);
+        $output->write($this->csvEscape($data, $delimiter, $enclosure, $escapeChar));
     }
 
-    protected function csvEscape($data, $delimiter = ',')
+  /**
+   * Generates a CSV-escaped string from an array of field data.
+   *
+   * @param array $data an array of field data to format as a CSV.
+   * @param string $delimiter the delimiter to use between fields.
+   * @param string $enclosure character to use when enclosing complex fields.
+   * @param string $escapeChar character to use when escaping special characters.
+   *
+   * @return string|bool the formatted CSV string, or FALSE if the formatting failed.
+   */
+    protected function csvEscape($data, $delimiter = ',', $enclosure = '"', $escapeChar = "\\")
     {
         $buffer = fopen('php://temp', 'r+');
-        fputcsv($buffer, $data, $delimiter);
+        fputcsv($buffer, $data, $delimiter, $enclosure, $escapeChar);
         rewind($buffer);
         $csv = fgets($buffer);
         fclose($buffer);

--- a/src/Formatters/CsvFormatter.php
+++ b/src/Formatters/CsvFormatter.php
@@ -118,7 +118,11 @@ class CsvFormatter implements FormatterInterface, ValidDataTypesInterface, Rende
     protected function csvEscape($data, $delimiter = ',', $enclosure = '"', $escapeChar = "\\")
     {
         $buffer = fopen('php://temp', 'r+');
-        fputcsv($buffer, $data, $delimiter, $enclosure, $escapeChar);
+        if (version_compare(PHP_VERSION, '5.5.4', '>=')) {
+            fputcsv($buffer, $data, $delimiter, $enclosure, $escapeChar);
+        } else {
+            fputcsv($buffer, $data, $delimiter, $enclosure);
+        }
         rewind($buffer);
         $csv = fgets($buffer);
         fclose($buffer);

--- a/src/Options/FormatterOptions.php
+++ b/src/Options/FormatterOptions.php
@@ -99,7 +99,7 @@ class FormatterOptions
 
     public function setCsvEscapeChar($escapeChar)
     {
-        return $this->setConfigurationValue(self::CSV_ENCLOSURE, $escapeChar);
+        return $this->setConfigurationValue(self::CSV_ESCAPE_CHAR, $escapeChar);
     }
 
     public function setListDelimiter($listDelimiter)

--- a/src/Options/FormatterOptions.php
+++ b/src/Options/FormatterOptions.php
@@ -46,6 +46,8 @@ class FormatterOptions
     const DEFAULT_FIELDS = 'default-fields';
     const DEFAULT_STRING_FIELD = 'default-string-field';
     const DELIMITER = 'delimiter';
+    const CSV_ENCLOSURE = 'csv-enclosure';
+    const CSV_ESCAPE_CHAR = 'csv-escape-char';
     const LIST_DELIMITER = 'list-delimiter';
     const TERMINAL_WIDTH = 'width';
     const METADATA_TEMPLATE = 'metadata-template';
@@ -88,6 +90,16 @@ class FormatterOptions
     public function setDelimiter($delimiter)
     {
         return $this->setConfigurationValue(self::DELIMITER, $delimiter);
+    }
+
+    public function setCsvEnclosure($enclosure)
+    {
+        return $this->setConfigurationValue(self::CSV_ENCLOSURE, $enclosure);
+    }
+
+    public function setCsvEscapeChar($escapeChar)
+    {
+        return $this->setConfigurationValue(self::CSV_ENCLOSURE, $escapeChar);
     }
 
     public function setListDelimiter($listDelimiter)

--- a/tests/FormattersTest.php
+++ b/tests/FormattersTest.php
@@ -670,6 +670,11 @@ EOT;
 
     public function testCsvEscapeCharOption()
     {
+        if (version_compare(PHP_VERSION, '5.5.4', '<')) {
+            $this->markTestIncomplete(
+                'The $escape_char argument for fputcsv is only supported by PHP 5.5.4 or above.'
+            );
+        }
         $data = [
             'Enclosed field with "double quotes"',
             'Enclosed field with \"backslash-prefixed double quotes\"',

--- a/tests/FormattersTest.php
+++ b/tests/FormattersTest.php
@@ -645,6 +645,53 @@ EOT;
 
         $this->assertFormattedOutputMatches($expected, 'csv', $data);
     }
+    public function testCsvEnclosureOption()
+    {
+        $data = [
+            'simple_field',
+            'Complex field that requires enclosure'
+        ];
+        $default_expected = 'simple_field,"Complex field that requires enclosure"';
+        $custom_expected = 'simple_field,~Complex field that requires enclosure~';
+
+        // First, ensure that the default enclosure style, double quote, is preserved
+        // as the default.
+        $this->assertFormattedOutputMatches($default_expected, 'csv', $data);
+
+        // Next, ensure that user-provided enclosure settings are respected.
+        $this->assertFormattedOutputMatches(
+            $custom_expected,
+            'csv',
+            $data,
+            new FormatterOptions(),
+            ['csv-enclosure' => '~']
+        );
+    }
+
+    public function testCsvEscapeCharOption()
+    {
+        $data = [
+            'Enclosed field with "double quotes"',
+            'Enclosed field with \"backslash-prefixed double quotes\"',
+        ];
+        $default_expected = '"Enclosed field with ""double quotes""",' .
+            '"Enclosed field with \"backslash-prefixed double quotes\""';
+        $custom_expected = '"Enclosed field with ""double quotes""",' .
+            '"Enclosed field with \""backslash-prefixed double quotes\"""';
+
+        // First, ensure that the default escape character, the double backslash, is preserved
+        // as the default.
+        $this->assertFormattedOutputMatches($default_expected, 'csv', $data);
+
+        // Next, ensure that user-provided escape character settings are respected.
+        $this->assertFormattedOutputMatches(
+            $custom_expected,
+            'csv',
+            $data,
+            new FormatterOptions(),
+            ['csv-escape-char' => "\0"]
+        );
+    }
 
     function testSimpleTsv()
     {


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes

### Summary
This PR addresses issue #78, extending CsvFormatter to support `fputcsv`'s optional `$enclosure` and `$escape_char` arguments.