### PR TITLE
Add @default-table-fields annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ All of the available fields will be listed in the `help` output for the command,
 
 To include all avalable fields, use `--fields=*`.
 
+Note that using the `@default-fields` annotation will reduce the number of fields included in the output for all formats, including unstructured formats such as json and yaml. To specify a reduced set of fields to display only when using a human-readable output format (e.g. table), use the `@default-table-fields` annotation instead.
+
 #### Reordering Fields
 
 Commands that return table structured data with fields can be filtered and/or re-ordered by using the `--fields` option. These structured data types can also be formatted into a more generic type such as yaml or json, even after being filtered. This capabilities are not available if the data is returned in a bare php array. One of `RowsOfFields`, `PropertyList` or `UnstructuredListData` (or similar) must be used.

--- a/src/FormatterManager.php
+++ b/src/FormatterManager.php
@@ -21,6 +21,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Consolidation\OutputFormatters\StructuredData\OriginalDataInterface;
 use Consolidation\OutputFormatters\StructuredData\ListDataFromKeys;
 use Consolidation\OutputFormatters\StructuredData\ConversionInterface;
+use Consolidation\OutputFormatters\Formatters\HumanReadableFormat;
 
 /**
  * Manage a collection of formatters; return one on request.
@@ -430,6 +431,11 @@ class FormatterManager
      */
     public function overrideOptions(FormatterInterface $formatter, $structuredOutput, FormatterOptions $options)
     {
+        // Set the "Human Readable" option if the formatter has the HumanReadable marker interface
+        if ($formatter instanceof HumanReadableFormat) {
+            $options->setHumanReadable();
+        }
+        // The formatter may also make dynamic adjustment to the options.
         if ($formatter instanceof OverrideOptionsInterface) {
             return $formatter->overrideOptions($structuredOutput, $options);
         }

--- a/src/Options/FormatterOptions.php
+++ b/src/Options/FormatterOptions.php
@@ -44,6 +44,7 @@ class FormatterOptions
     const ROW_LABELS = 'row-labels';
     const FIELD_LABELS = 'field-labels';
     const DEFAULT_FIELDS = 'default-fields';
+    const DEFAULT_TABLE_FIELDS = 'default-table-fields';
     const DEFAULT_STRING_FIELD = 'default-string-field';
     const DELIMITER = 'delimiter';
     const CSV_ENCLOSURE = 'csv-enclosure';
@@ -51,6 +52,7 @@ class FormatterOptions
     const LIST_DELIMITER = 'list-delimiter';
     const TERMINAL_WIDTH = 'width';
     const METADATA_TEMPLATE = 'metadata-template';
+    const HUMAN_READABLE = 'human-readable';
 
     /**
      * Create a new FormatterOptions with the configuration data and the
@@ -142,6 +144,11 @@ class FormatterOptions
     public function setWidth($width)
     {
         return $this->setConfigurationValue(self::TERMINAL_WIDTH, $width);
+    }
+
+    public function setHumanReadable($isHumanReadable = true)
+    {
+        return $this->setConfigurationValue(self::HUMAN_READABLE, $isHumanReadable);
     }
 
     /**

--- a/src/StructuredData/AbstractListData.php
+++ b/src/StructuredData/AbstractListData.php
@@ -36,9 +36,16 @@ class AbstractListData extends \ArrayObject implements ListDataInterface
         if (!empty($fieldShortcut)) {
             return [$fieldShortcut];
         }
-        $result = $options->get(FormatterOptions::FIELDS, $defaults);
+        $result = $options->get(FormatterOptions::FIELDS);
         if (!empty($result)) {
             return $result;
+        }
+        $isHumanReadable = $options->get(FormatterOptions::HUMAN_READABLE);
+        if ($isHumanReadable) {
+            $result = $options->get(FormatterOptions::DEFAULT_TABLE_FIELDS);
+            if (!empty($result)) {
+                return $result;
+            }
         }
         return $options->get(FormatterOptions::DEFAULT_FIELDS, $defaults);
     }


### PR DESCRIPTION
Add @default-table-fields annotation to allow commands to specify which fields to use by default in human-readable / table formats.

### Overview
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
The `@default-table-fields` annotation works like `@default-fields`, but is only selected when the output format is `table` or some other "human-readable" format.