### PR TITLE
Updating AnnotationCommand links to AnnotatedCommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Apply transformations to structured data to write output in different formats.
 
 Formatters are used to allow simple commandline tool commands to be implemented in a manner that is completely independent from the Symfony Console output interfaces.  A command receives its input via its method parameters, and returns its result as structured data (e.g. a php standard object or array).  The structured data is then formatted by a formatter, and the result is printed.
 
-This process is managed by the [Consolidation/AnnotationCommand](https://github.com/consolidation/annotation-command) project.
+This process is managed by the [Consolidation/AnnotatedCommand](https://github.com/consolidation/annotated-command) project.
 
 ## Library Usage
 
@@ -285,7 +285,7 @@ use Consolidation\OutputFormatters\StructuredData\NumericCellRenderer;
 
 ## API Usage
 
-It is recommended to use [Consolidation/AnnotationCommand](https://github.com/consolidation/annotation-command) to manage commands and formatters.  See the [AnnotationCommand API Usage](https://github.com/consolidation/annotation-command#api-usage) for details.
+It is recommended to use [Consolidation/AnnotatedCommand](https://github.com/consolidation/annotated-command) to manage commands and formatters.  See the [AnnotatedCommand API Usage](https://github.com/consolidation/annotated-command#api-usage) for details.
 
 The FormatterManager may also be used directly, if desired:
 ```php


### PR DESCRIPTION
### Overview
This pull request:

Changes the links in the Readme to the AnnotatedCommand project

### Summary
It appears that in [an early commit](/consolidation/annotated-command/commit/3ecc2534cf445ad62aac1a9fe96ba3f0261779e9) that the referenced project was renamed, but these links were not updated.

AnnotationCommand became AnnotatedCommand.