### PR TITLE
Update formatting of auto-option description

### DIFF
--- a/src/FormatterManager.php
+++ b/src/FormatterManager.php
@@ -136,7 +136,7 @@ class FormatterManager
         }
 
         if (isset($automaticOptions[FormatterOptions::FIELDS])) {
-            $automaticOptions[FormatterOptions::FIELD] = new InputOption(FormatterOptions::FIELD, '', InputOption::VALUE_REQUIRED, "Select just one field, and force format to 'string'.", '');
+            $automaticOptions[FormatterOptions::FIELD] = new InputOption(FormatterOptions::FIELD, '', InputOption::VALUE_REQUIRED, "Select just one field, and force format to *string*.", '');
         }
 
         return $automaticOptions;

--- a/tests/ValidFormatsTest.php
+++ b/tests/ValidFormatsTest.php
@@ -80,7 +80,7 @@ class ValidFormatsTest extends TestCase
             ]
         );
         $inputOptions = $this->formatterManager->automaticOptions($formatterOptions, $rowsOfFieldsRef);
-        $this->assertInputOptionDescriptionsEquals("Format the result data. Available formats: csv,json,list,null,php,print-r,sections,string,table,tsv,var_dump,var_export,xml,yaml [Default: 'table']\nAvailable fields: Name (name), Phone Number (phone_number) [Default: '']\nSelect just one field, and force format to 'string'. [Default: '']", $inputOptions);
+        $this->assertInputOptionDescriptionsEquals("Format the result data. Available formats: csv,json,list,null,php,print-r,sections,string,table,tsv,var_dump,var_export,xml,yaml [Default: 'table']\nAvailable fields: Name (name), Phone Number (phone_number) [Default: '']\nSelect just one field, and force format to *string*. [Default: '']", $inputOptions);
     }
 
     function assertInputOptionDescriptionsEquals($expected, $inputOptions)


### PR DESCRIPTION
Using an asterisk improves formatting on Drush CLI and on www.drush.org command help.

### Overview
This pull request:

- [ ] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Short overview of what changed.

### Description
Any additional information.
