### PR TITLE
Remove unused __constructor() method.

### DIFF
--- a/src/StructuredData/RowsOfFieldsWithMetadata.php
+++ b/src/StructuredData/RowsOfFieldsWithMetadata.php
@@ -11,11 +11,6 @@ class RowsOfFieldsWithMetadata extends RowsOfFields implements MetadataInterface
 {
     use MetadataHolderTrait;
 
-    public function __constructor($data)
-    {
-        parent::__construct($data);
-    }
-
     /**
      * Restructure this data for output by converting it into a table
      * transformation object. First, though, remove any metadata items.


### PR DESCRIPTION
PHP CS is complaining about the function name "__constructor":

Method name "RowsOfFieldsWithMetadata::__constructor" is discouraged; PHP has reserved all method names with a double underscore prefix for future use.

I presume that it was meant to be __construct(); as it stands, it appears this is not actually doing something (unless something else is also using this incorrectly named function..?)

### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Short overview of what changed.

### Description
Any additional information.
