### PR TITLE
Prevent PHP 8.1 warnings on empty cells

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,8 @@ jobs:
       - name: Install roave/backward-compatibility-check
         run: |
           mkdir -p tools
+          echo '{}' > tools/composer.json
+          composer --working-dir=tools config --no-plugins allow-plugins.ocramius/package-versions true
           composer --working-dir=tools require roave/backward-compatibility-check:^5
 
       - name: Run roave/backward-compatibility-check

--- a/composer.json
+++ b/composer.json
@@ -37,10 +37,7 @@
     },
     "config": {
         "optimize-autoloader": true,
-        "sort-packages": true,
-        "allow-plugins": {
-            "ocramius/package-versions": true
-        }
+        "sort-packages": true
     },
     "scripts": {
         "cs": "phpcs --standard=PSR2 -n src",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,10 @@
     },
     "config": {
         "optimize-autoloader": true,
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "ocramius/package-versions": true
+        }
     },
     "scripts": {
         "cs": "phpcs --standard=PSR2 -n src",

--- a/src/Transformations/Wrap/CalculateWidths.php
+++ b/src/Transformations/Wrap/CalculateWidths.php
@@ -79,7 +79,7 @@ class CalculateWidths
         // word in each column.
         foreach ($rows as $rowkey => $row) {
             foreach ($row as $colkey => $cell) {
-                $value = $fn($cell);
+                $value = $fn((string) $cell);
                 if ((!isset($widths[$colkey]) || ($widths[$colkey] < $value))) {
                     $widths[$colkey] = $value;
                 }


### PR DESCRIPTION
### Overview
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary

On PHP 8.1 a `null` cell will create a warning:

> Deprecated function: strlen(): Passing null to parameter #1 ($string) of type string is deprecated in Consolidation\OutputFormatters\Transformations\Wrap\CalculateWidths->Consolidation\OutputFormatters\Transformations\Wrap\@closure() (line 56 of vendor/consolidation/output-formatters/src/Transformations/Wrap/CalculateWidths.php) 

Cast to string a cell when passed to the callback, in `CalculateWidths::calculateColumnWidths()`.

