### PR TITLE
Add an accessor to get selected fields from the formatter object.

### DIFF
--- a/src/Options/FormatterOptions.php
+++ b/src/Options/FormatterOptions.php
@@ -167,6 +167,34 @@ class FormatterOptions
     }
 
     /**
+     * Get the fields based on the selections made by the user and
+     * the available annotation data.
+     *
+     * @param array $defaults
+     * @param mixed $default
+     * @return mixed
+     */
+    public function fields($defaults = [], $default = false)
+    {
+        $fieldShortcut = $this->get(self::FIELD, $defaults);
+        if (!empty($fieldShortcut)) {
+            return [$fieldShortcut];
+        }
+        $result = $this->get(self::FIELDS, $defaults);
+        if (!empty($result)) {
+            return $result;
+        }
+        $isHumanReadable = $this->get(self::HUMAN_READABLE, $defaults);
+        if ($isHumanReadable) {
+            $result = $this->get(self::DEFAULT_TABLE_FIELDS, $defaults);
+            if (!empty($result)) {
+                return $result;
+            }
+        }
+        return $this->get(self::DEFAULT_FIELDS, $defaults);
+    }
+
+    /**
      * Return the XmlSchema to use with --format=xml for data types that support
      * that.  This is used when an array needs to be converted into xml.
      *

--- a/src/StructuredData/AbstractListData.php
+++ b/src/StructuredData/AbstractListData.php
@@ -33,22 +33,7 @@ class AbstractListData extends \ArrayObject implements ListDataInterface
 
     protected function getFields($options, $defaults)
     {
-        $fieldShortcut = $options->get(FormatterOptions::FIELD);
-        if (!empty($fieldShortcut)) {
-            return [$fieldShortcut];
-        }
-        $result = $options->get(FormatterOptions::FIELDS);
-        if (!empty($result)) {
-            return $result;
-        }
-        $isHumanReadable = $options->get(FormatterOptions::HUMAN_READABLE);
-        if ($isHumanReadable) {
-            $result = $options->get(FormatterOptions::DEFAULT_TABLE_FIELDS);
-            if (!empty($result)) {
-                return $result;
-            }
-        }
-        return $options->get(FormatterOptions::DEFAULT_FIELDS, $defaults);
+        return $options->fields($defaults);
     }
 
     /**


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes

### Summary
Rather than hiding field selection inside the abstract list structured data class, make it available in the formatter options.
