### PR TITLE
Add convenience function FormatterOptions::fieldsContain()

### DIFF
--- a/src/Options/FormatterOptions.php
+++ b/src/Options/FormatterOptions.php
@@ -168,7 +168,9 @@ class FormatterOptions
 
     /**
      * Get the fields based on the selections made by the user and
-     * the available annotation data.
+     * the available annotation data. The fields are reported as the
+     * user selected them, and therefore may be either the field machine
+     * name, or its corresponding human-readable label.
      *
      * @param array $defaults
      * @param mixed $default
@@ -192,6 +194,40 @@ class FormatterOptions
             }
         }
         return $this->get(self::DEFAULT_FIELDS, $defaults);
+    }
+
+    /**
+     * Returns 'true' iff the fields selected by the user (or the default
+     * fields, if none explicitly selected) contain the specified field name.
+     * Note that the provided field name may be either the machine name for
+     * the field, or the human-readable field label.
+     */
+    public function fieldsContain($fieldName)
+    {
+        $fields = explode(',', $this->fields());
+
+        $fieldAlias = $this->fieldAlias($fieldName);
+
+        return in_array($fieldName, $fields) || in_array($fieldAlias, $fields);
+    }
+
+    protected function fieldAlias($fieldName)
+    {
+        $availableFields = $this->get(FormatterOptions::FIELD_LABELS);
+        if (!$availableFields) {
+            return $fieldName;
+        }
+
+        if (array_key_exists($fieldName, $availableFields)) {
+            return $availableFields[$fieldName];
+        }
+
+        $availableLabels = array_flip($availableFields);
+        if (array_key_exists($fieldName, $availableLabels)) {
+            return $availableLabels[$fieldName];
+        }
+
+        return $fieldName;
     }
 
     /**

--- a/tests/FormatterOptionsTest.php
+++ b/tests/FormatterOptionsTest.php
@@ -47,7 +47,8 @@ class FormatterOptionsTests extends TestCase
      */
     protected function getFormat(FormatterOptions $options, $defaults = [])
     {
-        return $options->get(FormatterOptions::FORMAT, [], $options->get(FormatterOptions::DEFAULT_FORMAT, $defaults, ''));
+        return $options->getFormat($defaults);
+        // return $options->get(FormatterOptions::FORMAT, [], $options->get(FormatterOptions::DEFAULT_FORMAT, $defaults, ''));
     }
 
     /**
@@ -127,5 +128,85 @@ class FormatterOptionsTests extends TestCase
         // We won't see the default value unless the configuration value is empty.
         $options = new FormatterOptions([], $userOptions);
         $this->assertEquals('var_export', $options->get(FormatterOptions::DEFAULT_FORMAT, $defaults, 'irrelevant'));
+    }
+
+    public function testFormatterOptionsFields()
+    {
+        $configurationData = [
+            FormatterOptions::DEFAULT_TABLE_FIELDS => 'a,b,c',
+            FormatterOptions::DEFAULT_FIELDS => 'a,b,c,d',
+            FormatterOptions::FIELD_LABELS => [
+                'a' => 'First',
+                'b' => 'Second',
+                'c' => 'Third',
+                'd' => 'Fourth'
+            ],
+        ];
+
+        $userOptions = [];
+
+        $options = new FormatterOptions($configurationData, $userOptions);
+
+        $this->assertEquals('a,b,c,d', $options->fields());
+
+        $this->assertEquals('a', $this->callProtected($options, 'fieldAlias', ['First']));
+        $this->assertEquals('First', $this->callProtected($options, 'fieldAlias', ['a']));
+
+        $this->assertTrue($options->fieldsContain('a'));
+        $this->assertTrue($options->fieldsContain('First'));
+
+        $this->assertTrue($options->fieldsContain('c'));
+        $this->assertTrue($options->fieldsContain('Third'));
+
+        $this->assertTrue($options->fieldsContain('d'));
+        $this->assertTrue($options->fieldsContain('Fourth'));
+
+        $options->setHumanReadable(true);
+
+        $this->assertEquals('a,b,c', $options->fields());
+
+        $this->assertTrue($options->fieldsContain('a'));
+        $this->assertTrue($options->fieldsContain('First'));
+
+        $this->assertTrue($options->fieldsContain('c'));
+        $this->assertTrue($options->fieldsContain('Third'));
+
+        $this->assertFalse($options->fieldsContain('d'));
+        $this->assertFalse($options->fieldsContain('Fourth'));
+
+        $userOptions = [
+            FormatterOptions::FIELDS => 'a,b',
+        ];
+
+        $options = new FormatterOptions($configurationData, $userOptions);
+
+        $this->assertTrue($options->fieldsContain('a'));
+        $this->assertTrue($options->fieldsContain('First'));
+
+        $this->assertFalse($options->fieldsContain('c'));
+        $this->assertFalse($options->fieldsContain('Third'));
+
+        $this->assertFalse($options->fieldsContain('d'));
+        $this->assertFalse($options->fieldsContain('Fourth'));
+
+        $options->setHumanReadable(true);
+
+        $this->assertTrue($options->fieldsContain('a'));
+        $this->assertTrue($options->fieldsContain('First'));
+
+        $this->assertFalse($options->fieldsContain('c'));
+        $this->assertFalse($options->fieldsContain('Third'));
+
+        $this->assertFalse($options->fieldsContain('d'));
+        $this->assertFalse($options->fieldsContain('Fourth'));
+
+
+    }
+
+    function callProtected($object, $method, $args = [])
+    {
+        $r = new \ReflectionMethod($object, $method);
+        $r->setAccessible(true);
+        return $r->invokeArgs($object, $args);
     }
 }


### PR DESCRIPTION
### Overview
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes

### Summary
Adds a convenience method FormatterOptions::fieldsContain() so that callers may determine if a certain field will be included in the output, e.g. so that they can omit calculating slow fields if they were not requested.