### PR TITLE
Wordwrap fix for tables

### DIFF
--- a/src/Transformations/WordWrapper.php
+++ b/src/Transformations/WordWrapper.php
@@ -138,6 +138,11 @@ class WordWrapper
         if (!is_string($cell)) {
             return $cell;
         }
+
+        if ($cellWidth == 0) {
+            // Fourth parameter cannot be true if parameter 2 is 0.
+            return wordwrap($cell, $cellWidth, "\n", false);
+        }
         return wordwrap($cell, $cellWidth, "\n", true);
     }
 }


### PR DESCRIPTION
### Overview
This pull request:

- [ * ] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Short overview of what changed.
Detects 0 cellwidth to allow a poorly formatted table to render instead of an error in the command line.

### Description
Any additional information.
