### PR TITLE
Allow Symfony 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,14 +21,14 @@
     "require": {
         "php": ">=7.1.3",
         "dflydev/dot-access-data": "^1.1.0 || ^2 || ^3",
-        "symfony/console": "^4 || ^5 || ^6 || ^7",
-        "symfony/finder": "^4 || ^5 || ^6 || ^7"
+        "symfony/console": "^4 || ^5 || ^6 || ^7 || ^8",
+        "symfony/finder": "^4 || ^5 || ^6 || ^7 || ^8"
     },
     "require-dev": {
         "php-coveralls/php-coveralls": "^2.4.2",
         "squizlabs/php_codesniffer": "^3",
-        "symfony/var-dumper": "^4 || ^5 || ^6 || ^7",
-        "symfony/yaml": "^4 || ^5 || ^6 || ^7",
+        "symfony/var-dumper": "^4 || ^5 || ^6 || ^7 || ^8",
+        "symfony/yaml": "^4 || ^5 || ^6 || ^7 || ^8",
         "phpunit/phpunit": "^7 || ^8 || ^9",
         "yoast/phpunit-polyfills": "^1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bc25a721ed09cb54689690320d8701bc",
+    "content-hash": "06d9abe64b49003785f483dc41782123",
     "packages": [
         {
             "name": "dflydev/dot-access-data",


### PR DESCRIPTION
Widen symfony/* constraints to allow ^8.

No code changes needed — verified that the APIs used by this package are unchanged in Symfony 8.

Ref: https://github.com/drush-ops/drush/issues/6536